### PR TITLE
supporting `getFontScale` in App Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,8 +686,6 @@ Gets the device font scale.
 The font scale is the ratio of the current system font to the "normal" font size, so if normal text is 10pt and the system font is currently 15pt, the font scale would be 1.5
 This can be used to determine if accessability settings has been changed for the device; you may want to re-layout certain views if the font scale is significantly larger ( > 2.0 )
 
-In iOS App Extensions this call always returns 1.0, see #625.
-
 #### Examples
 
 ```js

--- a/example/App.js
+++ b/example/App.js
@@ -7,7 +7,7 @@
  * @lint-ignore-every XPLATJSCOPYRIGHT1
  */
 
-import React, {Component} from 'react';
+import React, {Component, useCallback, memo} from 'react';
 import {
   ScrollView,
   StyleSheet,
@@ -15,6 +15,7 @@ import {
   SafeAreaView,
   View,
   TouchableOpacity,
+  NativeModules,
 } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import {
@@ -62,6 +63,32 @@ const FunctionalComponent = () => {
     </ScrollView>
   );
 };
+
+const ActionExtensionHeader = memo(({isActionExtension}) => {
+  const onDonePress = useCallback(() => {
+    NativeModules.ActionExtension.done();
+  }, []);
+  return isActionExtension ? (
+    <View style={{minHeight: 50, flexDirection: 'row', margin: 10}}>
+      <TouchableOpacity onPress={onDonePress}>
+        <View
+          style={{
+            backgroundColor: 'red',
+            borderRadius: 20,
+            minWidth: 80,
+            minHeight: 40,
+            alignContent: 'center',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
+          <Text>Done</Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  ) : (
+    <View />
+  );
+});
 
 export default class App extends Component {
   constructor(props) {
@@ -237,6 +264,9 @@ export default class App extends Component {
   render() {
     return (
       <SafeAreaView style={styles.container}>
+        <ActionExtensionHeader
+          isActionExtension={this.props.isActionExtension}
+        />
         {this.state.activeTab === 'constant' ? (
           <>
             <Text style={styles.welcome}>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -82,6 +82,10 @@ target 'example' do
     # Pods for testing
   end
 
+  target 'example-app-extension' do
+    inherit! :complete
+  end
+
   use_native_modules!
 
   # Enables Flipper.
@@ -91,8 +95,15 @@ target 'example' do
   add_flipper_pods!
   post_install do |installer|
     flipper_post_install(installer)
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = 'NO'
+      end
+    end
   end
 end
+
+
 
 target 'example-tvOS' do
   # Pods for example-tvOS

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -15,12 +15,12 @@ PODS:
     - Flipper-Folly (~> 2.1)
     - Flipper-RSocket (~> 1.0)
   - Flipper-DoubleConversion (1.1.7)
-  - Flipper-Folly (2.2.0):
+  - Flipper-Folly (2.3.0):
     - boost-for-react-native
     - CocoaLibEvent (~> 1.0)
     - Flipper-DoubleConversion
     - Flipper-Glog
-    - OpenSSL-Universal (= 1.0.2.19)
+    - OpenSSL-Universal (= 1.0.2.20)
   - Flipper-Glog (0.3.6)
   - Flipper-PeerTalk (0.0.4)
   - Flipper-RSocket (1.1.0):
@@ -67,9 +67,9 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - OpenSSL-Universal (1.0.2.19):
-    - OpenSSL-Universal/Static (= 1.0.2.19)
-  - OpenSSL-Universal/Static (1.0.2.19)
+  - OpenSSL-Universal (1.0.2.20):
+    - OpenSSL-Universal/Static (= 1.0.2.20)
+  - OpenSSL-Universal/Static (1.0.2.20)
   - RCTRequired (0.62.2)
   - RCTTypeSafety (0.62.2):
     - FBLazyVector (= 0.62.2)
@@ -426,14 +426,14 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
   Flipper: 6c1f484f9a88d30ab3e272800d53688439e50f69
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
-  Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
+  Flipper-Folly: e4493b013c02d9347d5e0cb4d128680239f6c78a
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
   FlipperKit: 6dc9b8f4ef60d9e5ded7f0264db299c91f18832e
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
+  OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
   RCTRequired: cec6a34b3ac8a9915c37e7e4ad3aa74726ce4035
   RCTTypeSafety: 93006131180074cffa227a1075802c89a49dd4ce
   React: 29a8b1a02bd764fb7644ef04019270849b9a7ac3
@@ -457,6 +457,6 @@ SPEC CHECKSUMS:
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 56c2537f71f3f02200d6918c542a8e89a0b422fa
+PODFILE CHECKSUM: f91bb4689a35e41582db283feebcc6070b90b20f
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.9.1

--- a/example/ios/example-app-extension/ActionViewController.h
+++ b/example/ios/example-app-extension/ActionViewController.h
@@ -1,0 +1,14 @@
+//
+//  ActionViewController.h
+//  example-app-extension
+//
+//  Created by Dustin Schie on 10/13/20.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ActionViewController : UIViewController
+- (void) done;
+
+extern ActionViewController * actionViewController;
+@end

--- a/example/ios/example-app-extension/ActionViewController.m
+++ b/example/ios/example-app-extension/ActionViewController.m
@@ -1,0 +1,42 @@
+//
+//  ActionViewController.m
+//  example-app-extension
+//
+//  Created by Dustin Schie on 10/13/20.
+//
+
+#import "ActionViewController.h"
+#import <MobileCoreServices/MobileCoreServices.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+@interface ActionViewController ()
+
+@property(strong,nonatomic) IBOutlet UIImageView *imageView;
+
+@end
+
+ActionViewController * actionViewController = nil;
+
+@implementation ActionViewController
+
+- (void)loadView {
+    NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+    NSDictionary *initialProps = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool: TRUE] forKey:@"isActionExtension"];
+    RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
+                                                        moduleName:@"example"
+                                                 initialProperties:initialProps
+                                                     launchOptions:nil];
+    rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+    self.view = rootView;
+  actionViewController = self;
+  }
+
+- (void)done {
+    // Return any edited content to the host app.
+    // This template doesn't do anything, so we just echo the passed in items.
+    [self.extensionContext completeRequestReturningItems:self.extensionContext.inputItems completionHandler:nil];
+  actionViewController = nil;
+}
+
+@end

--- a/example/ios/example-app-extension/Base.lproj/MainInterface.storyboard
+++ b/example/ios/example-app-extension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ObA-dk-sSI">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Image-->
+        <scene sceneID="7MM-of-jgj">
+            <objects>
+                <viewController title="Image" id="ObA-dk-sSI" customClass="ActionViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="zMn-AG-sqS">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="528"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9ga-4F-77Z">
+                                <rect key="frame" x="0.0" y="528" width="320" height="0.0"/>
+                            </imageView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="VVe-Uw-JpX"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="VVe-Uw-JpX" firstAttribute="trailing" secondItem="9ga-4F-77Z" secondAttribute="trailing" id="Ozw-Hg-0yh"/>
+                            <constraint firstItem="9ga-4F-77Z" firstAttribute="leading" secondItem="VVe-Uw-JpX" secondAttribute="leading" id="XH5-ld-ONA"/>
+                            <constraint firstItem="VVe-Uw-JpX" firstAttribute="bottom" secondItem="9ga-4F-77Z" secondAttribute="bottom" id="eQg-nn-Zy4"/>
+                            <constraint firstItem="9ga-4F-77Z" firstAttribute="top" secondItem="VVe-Uw-JpX" secondAttribute="top" constant="484" id="zAn-4q-vpp"/>
+                        </constraints>
+                    </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="528"/>
+                    <connections>
+                        <outlet property="imageView" destination="9ga-4F-77Z" id="5y6-5w-9QO"/>
+                        <outlet property="view" destination="zMn-AG-sqS" id="Qma-de-2ek"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="X47-rx-isc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-196" y="48"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/example/ios/example-app-extension/Info.plist
+++ b/example/ios/example-app-extension/Info.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>example-app-extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+			<key>NSExtensionServiceAllowsFinderPreviewItem</key>
+			<true/>
+			<key>NSExtensionServiceAllowsTouchBarItem</key>
+			<true/>
+			<key>NSExtensionServiceFinderPreviewIconName</key>
+			<string>NSActionTemplate</string>
+			<key>NSExtensionServiceTouchBarBezelColorName</key>
+			<string>TouchBarBezel</string>
+			<key>NSExtensionServiceTouchBarIconName</key>
+			<string>NSActionTemplate</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.ui-services</string>
+	</dict>
+</dict>
+</plist>

--- a/example/ios/example-app-extension/Media.xcassets/Contents.json
+++ b/example/ios/example-app-extension/Media.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example/ios/example-app-extension/Media.xcassets/TouchBarBezel.colorset/Contents.json
+++ b/example/ios/example-app-extension/Media.xcassets/TouchBarBezel.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "mac",
+      "color" : {
+        "reference" : "systemPurpleColor"
+      }
+    }
+  ]
+}

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -8,9 +8,17 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* exampleTests.m */; };
+		0A1159D225361DF3009B319B /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A1159D125361DF3009B319B /* Media.xcassets */; };
+		0A1159D525361DF3009B319B /* ActionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A1159D425361DF3009B319B /* ActionViewController.m */; };
+		0A1159D825361DF3009B319B /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A1159D625361DF3009B319B /* MainInterface.storyboard */; };
+		0A1159DC25361DF3009B319B /* example-app-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 0A1159CF25361DF2009B319B /* example-app-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0A115AF525362B4F009B319B /* ActionExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A115AF425362B4F009B319B /* ActionExtension.m */; };
+		0A115AF625362B4F009B319B /* ActionExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A115AF425362B4F009B319B /* ActionExtension.m */; };
+		0A115B2C25363417009B319B /* ActionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A1159D425361DF3009B319B /* ActionViewController.m */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		14DCD9FA7B1DEC835B800C03 /* libPods-example-example-app-extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5079447ACC50C5A446EC11CE /* libPods-example-example-app-extension.a */; };
 		18BE5FD97BBA79BA03CF1A71 /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 883D940B9C169B6E8BB546E2 /* libPods-example.a */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
@@ -30,6 +38,13 @@
 			remoteGlobalIDString = 13B07F861A680F5B00A75B9A;
 			remoteInfo = example;
 		};
+		0A1159DA25361DF3009B319B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0A1159CE25361DF2009B319B;
+			remoteInfo = "example-app-extension";
+		};
 		2D02E4911E0B4A5D006451C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
@@ -39,11 +54,34 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		0A1159DD25361DF3009B319B /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				0A1159DC25361DF3009B319B /* example-app-extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		00E356EE1AD99517003FC87E /* exampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = exampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* exampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = exampleTests.m; sourceTree = "<group>"; };
+		0A1159CF25361DF2009B319B /* example-app-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "example-app-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A1159D125361DF3009B319B /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		0A1159D325361DF3009B319B /* ActionViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActionViewController.h; sourceTree = "<group>"; };
+		0A1159D425361DF3009B319B /* ActionViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ActionViewController.m; sourceTree = "<group>"; };
+		0A1159D725361DF3009B319B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		0A1159D925361DF3009B319B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0A115AF325362B4F009B319B /* ActionExtension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ActionExtension.h; path = example/ActionExtension.h; sourceTree = "<group>"; };
+		0A115AF425362B4F009B319B /* ActionExtension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ActionExtension.m; path = example/ActionExtension.m; sourceTree = "<group>"; };
+		0EE90D0D325F65D25D6ABC62 /* Pods-example-example-app-extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-example-app-extension.release.xcconfig"; path = "Target Support Files/Pods-example-example-app-extension/Pods-example-example-app-extension.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = example/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = example/AppDelegate.m; sourceTree = "<group>"; };
@@ -56,13 +94,17 @@
 		2D02E47B1E0B4A5D006451C7 /* example-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* example-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "example-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		402425FCFFA655E810D6B961 /* Pods-example-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvOS.release.xcconfig"; path = "Target Support Files/Pods-example-tvOS/Pods-example-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		5079447ACC50C5A446EC11CE /* libPods-example-example-app-extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example-example-app-extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		65321D632131121666E93D37 /* Pods-example-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-example-tvOSTests/Pods-example-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		681823D04773DC88B85187F5 /* libPods-example-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E15CF53C9549FF1EFC65A06 /* Pods-example-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-example-tvOS/Pods-example-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		7B68DDF1556E59FE902D5ECC /* Pods-example-exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-exampleTests.debug.xcconfig"; path = "Target Support Files/Pods-example-exampleTests/Pods-example-exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = example/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		8385009DD9088A2E803A8B62 /* Pods-example-app-extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-app-extension.debug.xcconfig"; path = "Target Support Files/Pods-example-app-extension/Pods-example-app-extension.debug.xcconfig"; sourceTree = "<group>"; };
 		87D210DD5119F9C07EDC6A60 /* libPods-example-tvOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example-tvOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		883D940B9C169B6E8BB546E2 /* libPods-example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE8321B950040DA273930F19 /* Pods-example-example-app-extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-example-app-extension.debug.xcconfig"; path = "Target Support Files/Pods-example-example-app-extension/Pods-example-example-app-extension.debug.xcconfig"; sourceTree = "<group>"; };
+		C51D473CA66377ADE279DDAE /* Pods-example-app-extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-app-extension.release.xcconfig"; path = "Target Support Files/Pods-example-app-extension/Pods-example-app-extension.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		F118DDE23818D7A862E7DF9D /* Pods-example-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-example-tvOSTests/Pods-example-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -75,6 +117,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				A13AA478EAF4EBE7F147362C /* libPods-example-exampleTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0A1159CC25361DF2009B319B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				14DCD9FA7B1DEC835B800C03 /* libPods-example-example-app-extension.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,6 +172,18 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		0A1159D025361DF3009B319B /* example-app-extension */ = {
+			isa = PBXGroup;
+			children = (
+				0A1159D125361DF3009B319B /* Media.xcassets */,
+				0A1159D325361DF3009B319B /* ActionViewController.h */,
+				0A1159D425361DF3009B319B /* ActionViewController.m */,
+				0A1159D625361DF3009B319B /* MainInterface.storyboard */,
+				0A1159D925361DF3009B319B /* Info.plist */,
+			);
+			path = "example-app-extension";
+			sourceTree = "<group>";
+		};
 		13B07FAE1A68108700A75B9A /* example */ = {
 			isa = PBXGroup;
 			children = (
@@ -132,6 +194,8 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				0A115AF325362B4F009B319B /* ActionExtension.h */,
+				0A115AF425362B4F009B319B /* ActionExtension.m */,
 			);
 			name = example;
 			sourceTree = "<group>";
@@ -147,8 +211,11 @@
 				402425FCFFA655E810D6B961 /* Pods-example-tvOS.release.xcconfig */,
 				F118DDE23818D7A862E7DF9D /* Pods-example-tvOSTests.debug.xcconfig */,
 				65321D632131121666E93D37 /* Pods-example-tvOSTests.release.xcconfig */,
+				8385009DD9088A2E803A8B62 /* Pods-example-app-extension.debug.xcconfig */,
+				C51D473CA66377ADE279DDAE /* Pods-example-app-extension.release.xcconfig */,
+				BE8321B950040DA273930F19 /* Pods-example-example-app-extension.debug.xcconfig */,
+				0EE90D0D325F65D25D6ABC62 /* Pods-example-example-app-extension.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -161,6 +228,7 @@
 				FDA3F36E7284D62792F5F838 /* libPods-example-exampleTests.a */,
 				681823D04773DC88B85187F5 /* libPods-example-tvOS.a */,
 				87D210DD5119F9C07EDC6A60 /* libPods-example-tvOSTests.a */,
+				5079447ACC50C5A446EC11CE /* libPods-example-example-app-extension.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -178,6 +246,7 @@
 				13B07FAE1A68108700A75B9A /* example */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* exampleTests */,
+				0A1159D025361DF3009B319B /* example-app-extension */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
 				18626B5D626747DAAE7D37F3 /* Pods */,
@@ -194,6 +263,7 @@
 				00E356EE1AD99517003FC87E /* exampleTests.xctest */,
 				2D02E47B1E0B4A5D006451C7 /* example-tvOS.app */,
 				2D02E4901E0B4A5D006451C7 /* example-tvOSTests.xctest */,
+				0A1159CF25361DF2009B319B /* example-app-extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -220,6 +290,24 @@
 			productReference = 00E356EE1AD99517003FC87E /* exampleTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		0A1159CE25361DF2009B319B /* example-app-extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0A1159E025361DF3009B319B /* Build configuration list for PBXNativeTarget "example-app-extension" */;
+			buildPhases = (
+				C1DDCE3CA31795FDC755EA41 /* [CP] Check Pods Manifest.lock */,
+				0A1159CB25361DF2009B319B /* Sources */,
+				0A1159CC25361DF2009B319B /* Frameworks */,
+				0A1159CD25361DF2009B319B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "example-app-extension";
+			productName = "example-app-extension";
+			productReference = 0A1159CF25361DF2009B319B /* example-app-extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		13B07F861A680F5B00A75B9A /* example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "example" */;
@@ -230,10 +318,12 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				0A1159DD25361DF3009B319B /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				0A1159DB25361DF3009B319B /* PBXTargetDependency */,
 			);
 			name = example;
 			productName = example;
@@ -291,6 +381,10 @@
 						CreatedOnToolsVersion = 6.2;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
+					0A1159CE25361DF2009B319B = {
+						CreatedOnToolsVersion = 12.0.1;
+						ProvisioningStyle = Automatic;
+					};
 					13B07F861A680F5B00A75B9A = {
 						LastSwiftMigration = 1120;
 					};
@@ -322,6 +416,7 @@
 				00E356ED1AD99517003FC87E /* exampleTests */,
 				2D02E47A1E0B4A5D006451C7 /* example-tvOS */,
 				2D02E48F1E0B4A5D006451C7 /* example-tvOSTests */,
+				0A1159CE25361DF2009B319B /* example-app-extension */,
 			);
 		};
 /* End PBXProject section */
@@ -331,6 +426,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0A1159CD25361DF2009B319B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A1159D225361DF3009B319B /* Media.xcassets in Resources */,
+				0A1159D825361DF3009B319B /* MainInterface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -477,6 +581,28 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		C1DDCE3CA31795FDC755EA41 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-example-example-app-extension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -526,12 +652,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		0A1159CB25361DF2009B319B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A1159D525361DF3009B319B /* ActionViewController.m in Sources */,
+				0A115AF625362B4F009B319B /* ActionExtension.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		13B07F871A680F5B00A75B9A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A115B2C25363417009B319B /* ActionViewController.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				0A115AF525362B4F009B319B /* ActionExtension.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -560,12 +697,28 @@
 			target = 13B07F861A680F5B00A75B9A /* example */;
 			targetProxy = 00E356F41AD99517003FC87E /* PBXContainerItemProxy */;
 		};
+		0A1159DB25361DF3009B319B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0A1159CE25361DF2009B319B /* example-app-extension */;
+			targetProxy = 0A1159DA25361DF3009B319B /* PBXContainerItemProxy */;
+		};
 		2D02E4921E0B4A5D006451C7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2D02E47A1E0B4A5D006451C7 /* example-tvOS */;
 			targetProxy = 2D02E4911E0B4A5D006451C7 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		0A1159D625361DF3009B319B /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0A1159D725361DF3009B319B /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
@@ -608,6 +761,68 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/example.app/example";
+			};
+			name = Release;
+		};
+		0A1159DE25361DF3009B319B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BE8321B950040DA273930F19 /* Pods-example-example-app-extension.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "example-app-extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.example.example-app-extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0A1159DF25361DF3009B319B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0EE90D0D325F65D25D6ABC62 /* Pods-example-example-app-extension.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "example-app-extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.example.example-app-extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -886,6 +1101,15 @@
 			buildConfigurations = (
 				00E356F61AD99517003FC87E /* Debug */,
 				00E356F71AD99517003FC87E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0A1159E025361DF3009B319B /* Build configuration list for PBXNativeTarget "example-app-extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0A1159DE25361DF3009B319B /* Debug */,
+				0A1159DF25361DF3009B319B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/example/ios/example/ActionExtension.h
+++ b/example/ios/example/ActionExtension.h
@@ -1,0 +1,16 @@
+//
+//  ActionExtension.h
+//  example
+//
+//  Created by Dustin Schie on 10/13/20.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridge.h>
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ActionExtension : NSObject<RCTBridgeModule>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/example/ios/example/ActionExtension.m
+++ b/example/ios/example/ActionExtension.m
@@ -1,0 +1,16 @@
+//
+//  ActionExtension.m
+//  example
+//
+//  Created by Dustin Schie on 10/13/20.
+//
+#import "ActionExtension.h"
+#import "ActionViewController.h"
+
+@implementation ActionExtension
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(done) {
+  [actionViewController done];
+}
+@end

--- a/ios/RNDeviceInfo.xcodeproj/project.pbxproj
+++ b/ios/RNDeviceInfo.xcodeproj/project.pbxproj
@@ -228,15 +228,15 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-                                HEADER_SEARCH_PATHS = (
-                                        "$(inherited)",
-                                        "$(BUILT_PRODUCTS_DIR)/usr/local/include",
-                                        "$(SRCROOT)/../../React/**",
-                                        "$(SRCROOT)/node_modules/react-native/React/**",
-                                        "$(SRCROOT)/../react-native/React/**",
-                                        "$(SRCROOT)/../../../node_modules/react-native/React/**",
-                                );
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -272,15 +272,15 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-                                HEADER_SEARCH_PATHS = (
-                                        "$(inherited)",
-                                        "$(BUILT_PRODUCTS_DIR)/usr/local/include",
-                                        "$(SRCROOT)/../../React/**",
-                                        "$(SRCROOT)/node_modules/react-native/React/**",
-                                        "$(SRCROOT)/../react-native/React/**",
-                                        "$(SRCROOT)/../../../node_modules/react-native/React/**",
-                                );
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -417,13 +417,13 @@ RCT_EXPORT_METHOD(getDeviceToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPr
 - (float) getFontScale {
     // Font scales based on font sizes from https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/
     float fontScale = 1.0;
-    UIApplication *application = RCTSharedApplication();
+    UITraitCollection *traitCollection = [[UIScreen mainScreen] traitCollection];
 
     // Shared application is unavailable in an app extension.
-    if (application) {
+    if (traitCollection) {
         __block NSString *contentSize = nil;
         RCTUnsafeExecuteOnMainQueueSync(^{
-            contentSize = application.preferredContentSizeCategory;
+            contentSize = traitCollection.preferredContentSizeCategory;
         });
 
         if ([contentSize isEqual: @"UICTContentSizeCategoryXS"]) fontScale = 0.82;


### PR DESCRIPTION
## Description

Fixes #625

- updates how contentSize is obtained; using `[[UIScreen mainScreen] traitCollection];`
- updates example to include an app extension for testing and such **(MAJORITY OF THIS PR)**

BREAKING CHANGE: by obtaining the content size from `[[UIScreen mainScreen]
traitCollection].preferredContentSizeCategory` , this library drops support for iOS 9. This should
be fine since RN 0.63+ dropped support for iOS9 and the OS, itself, has <1% iOS market share.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [X] I added a sample use of the API (`example/App.js`)


## TL;DR
<img width="853" alt="image" src="https://user-images.githubusercontent.com/4561856/95918083-30735200-0d79-11eb-9723-7218a04c015f.png">

