### PR TITLE
fix(windows): remove use of Object.fromEntries

### DIFF
--- a/src/internal/supported-platform-info.ts
+++ b/src/internal/supported-platform-info.ts
@@ -23,10 +23,10 @@ function getSupportedFunction<T>(
   getter: Getter<T>,
   defaultGetter: Getter<T>
 ): Getter<T> {
-  const entries = supportedPlatforms
+  let supportedMap : any = {};
+  supportedPlatforms
     .filter((key) => Platform.OS == key)
-    .map((key) => [key, getter]);
-  const supportedMap = Object.fromEntries(entries);
+    .forEach((key) => supportedMap[key] = getter);
   return Platform.select({
     ...supportedMap,
     default: defaultGetter,


### PR DESCRIPTION
Object.fromEntries doesn't work in react-native-windows in release
builds or without the Web Debugger enabled.
Replace use of Object.fromEntries with equivalent code.

## Description

Fixes #1109

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for Windows
