### PR TITLE
more tests and a memoization bug fix

### DIFF
--- a/__tests__/getters.test.ts
+++ b/__tests__/getters.test.ts
@@ -210,6 +210,14 @@ describe('number getters', () => {
 });
 
 const memoizedBooleanGetters = ['isEmulator'].map(makeTable);
+const nonMemoizedBooleanGetters = [
+  'isCameraPresent',
+  'isPinOrFingerprintSet',
+  'isBatteryCharging',
+  'isAirplaneMode',
+  'isLocationEnabled',
+  'isHeadphonesConnected',
+].map(makeTable);
 
 describe('boolean getters', () => {
   describe.each(memoizedBooleanGetters)(
@@ -262,6 +270,52 @@ describe('boolean getters', () => {
         expect(resp).toBe(resp2);
         expect(asyncNativeGetter).toHaveBeenCalled();
         expect(syncNativeGetter).not.toHaveBeenCalled();
+      });
+    }
+  );
+
+  describe.each(nonMemoizedBooleanGetters)(
+    '%s*',
+    (_name, asyncGetter, syncGetter, asyncNativeGetter, syncNativeGetter) => {
+      beforeEach(() => {
+        clearMemo();
+        Platform.OS = 'android';
+        asyncNativeGetter.mockClear();
+        syncNativeGetter.mockClear();
+      });
+
+      it('should have an async version', () => {
+        expect(typeof asyncGetter).toBe('function');
+      });
+
+      it('should have a sync version', () => {
+        expect(typeof syncGetter).toBe('function');
+      });
+
+      it('should call native async module function', async () => {
+        const resp = await asyncGetter();
+        expect(resp).toEqual(false);
+        expect(asyncNativeGetter).toHaveBeenCalled();
+      });
+
+      it('should call native sync module function', () => {
+        const resp = syncGetter();
+        expect(resp).toEqual(false);
+        expect(syncNativeGetter).toHaveBeenCalled();
+      });
+
+      it('should not call native sync module function on unsupported OS', () => {
+        Platform.OS = 'GLaDOS' as any; // setting OS to something that won't match anything
+        const resp = syncGetter();
+        expect(resp).toEqual(false);
+        expect(syncNativeGetter).not.toHaveBeenCalled();
+      });
+
+      it('should not call native async module function on unsupported OS', async () => {
+        Platform.OS = 'GLaDOS' as any; // setting OS to something that won't match anything
+        const resp = await asyncGetter();
+        expect(resp).toEqual(false);
+        expect(asyncNativeGetter).not.toHaveBeenCalled();
       });
     }
   );

--- a/__tests__/getters.test.ts
+++ b/__tests__/getters.test.ts
@@ -213,3 +213,76 @@ describe('boolean getters', () => {
     }
   );
 });
+
+const memoizedArrayGetters = [
+  [
+    'supported32BitAbis', // name
+    (RNDeviceInfo as any).supported32BitAbis, // asyncGetter
+    (RNDeviceInfo as any).supported32BitAbisSync, // syncGetter
+    mockNativeModule.getSupported32BitAbis, // asyncNativeGetter
+    mockNativeModule.getSupported32BitAbisSync, // syncNativeGetter
+  ],
+  [
+    'supported64BitAbis', // name
+    (RNDeviceInfo as any).supported64BitAbis, // asyncGetter
+    (RNDeviceInfo as any).supported64BitAbisSync, // syncGetter
+    mockNativeModule.getSupported64BitAbis, // asyncNativeGetter
+    mockNativeModule.getSupported64BitAbisSync, // syncNativeGetter
+  ],
+];
+
+describe('array getters', () => {
+  describe.each(memoizedArrayGetters)(
+    '%s*',
+    (_name, asyncGetter, syncGetter, asyncNativeGetter, syncNativeGetter) => {
+      beforeEach(() => {
+        clearMemo();
+        Platform.OS = 'android';
+        asyncNativeGetter.mockClear();
+        syncNativeGetter.mockClear();
+      });
+
+      it('should have an async version', () => {
+        expect(typeof asyncGetter).toBe('function');
+      });
+
+      it('should have a sync version', () => {
+        expect(typeof syncGetter).toBe('function');
+      });
+
+      it('should call native async module function', async () => {
+        const resp = await asyncGetter();
+        expect(resp).toEqual([]);
+        expect(asyncNativeGetter).toHaveBeenCalled();
+      });
+
+      it('should call native sync module function', () => {
+        const resp = syncGetter();
+        expect(resp).toEqual([]);
+        expect(syncNativeGetter).toHaveBeenCalled();
+      });
+
+      it('should not call native sync module function on unsupported OS', () => {
+        Platform.OS = 'GLaDOS' as any; // setting OS to something that won't match anything
+        const resp = syncGetter();
+        expect(resp).toEqual([]);
+        expect(syncNativeGetter).not.toHaveBeenCalled();
+      });
+
+      it('should not call native async module function on unsupported OS', async () => {
+        Platform.OS = 'GLaDOS' as any; // setting OS to something that won't match anything
+        const resp = await asyncGetter();
+        expect(resp).toEqual([]);
+        expect(asyncNativeGetter).not.toHaveBeenCalled();
+      });
+
+      it('should use memoized value if there exists one', async () => {
+        const resp = await asyncGetter();
+        const resp2 = syncGetter();
+        expect(resp).toBe(resp2);
+        expect(asyncNativeGetter).toHaveBeenCalled();
+        expect(syncNativeGetter).not.toHaveBeenCalled();
+      });
+    }
+  );
+});

--- a/__tests__/getters.test.ts
+++ b/__tests__/getters.test.ts
@@ -90,3 +90,68 @@ describe('string getters', () => {
     }
   );
 });
+
+const memoizedNumberGetters = [
+  'getApiLevel',
+  'getPreviewSdkInt',
+  'getFirstInstallTime',
+  'getLastUpdateTime',
+  'getTotalMemory',
+  'getMaxMemory',
+].map(makeTable);
+
+describe('number getters', () => {
+  describe.each(memoizedNumberGetters)(
+    '%s*',
+    (_name, asyncGetter, syncGetter, asyncNativeGetter, syncNativeGetter) => {
+      beforeEach(() => {
+        clearMemo();
+        Platform.OS = 'android';
+        asyncNativeGetter.mockClear();
+        syncNativeGetter.mockClear();
+      });
+
+      it('should have an async version', () => {
+        expect(typeof asyncGetter).toBe('function');
+      });
+
+      it('should have a sync version', () => {
+        expect(typeof syncGetter).toBe('function');
+      });
+
+      it('should call native async module function', async () => {
+        const resp = await asyncGetter();
+        expect(resp).toEqual(-1);
+        expect(asyncNativeGetter).toHaveBeenCalled();
+      });
+
+      it('should call native sync module function', () => {
+        const resp = syncGetter();
+        expect(resp).toEqual(-1);
+        expect(syncNativeGetter).toHaveBeenCalled();
+      });
+
+      it('should not call native sync module function on unsupported OS', () => {
+        Platform.OS = 'GLaDOS' as any; // setting OS to something that won't match anything
+        const resp = syncGetter();
+        expect(resp).toEqual(-1);
+        expect(syncNativeGetter).not.toHaveBeenCalled();
+      });
+
+      it('should not call native async module function on unsupported OS', async () => {
+        Platform.OS = 'GLaDOS' as any; // setting OS to something that won't match anything
+        const resp = await asyncGetter();
+        expect(resp).toEqual(-1);
+        expect(asyncNativeGetter).not.toHaveBeenCalled();
+      });
+
+      it('should use memoized value if there exists one', async () => {
+        const resp = await asyncGetter();
+        const resp2 = syncGetter();
+        expect(resp).toBe(resp2);
+        expect(asyncNativeGetter).toHaveBeenCalled();
+        expect(syncNativeGetter).not.toHaveBeenCalled();
+      });
+    }
+  );
+});

--- a/__tests__/getters.test.ts
+++ b/__tests__/getters.test.ts
@@ -155,3 +155,61 @@ describe('number getters', () => {
     }
   );
 });
+
+const memoizedBooleanGetters = ['isEmulator'].map(makeTable);
+
+describe('boolean getters', () => {
+  describe.each(memoizedBooleanGetters)(
+    '%s*',
+    (_name, asyncGetter, syncGetter, asyncNativeGetter, syncNativeGetter) => {
+      beforeEach(() => {
+        clearMemo();
+        Platform.OS = 'android';
+        asyncNativeGetter.mockClear();
+        syncNativeGetter.mockClear();
+      });
+
+      it('should have an async version', () => {
+        expect(typeof asyncGetter).toBe('function');
+      });
+
+      it('should have a sync version', () => {
+        expect(typeof syncGetter).toBe('function');
+      });
+
+      it('should call native async module function', async () => {
+        const resp = await asyncGetter();
+        expect(resp).toEqual(false);
+        expect(asyncNativeGetter).toHaveBeenCalled();
+      });
+
+      it('should call native sync module function', () => {
+        const resp = syncGetter();
+        expect(resp).toEqual(false);
+        expect(syncNativeGetter).toHaveBeenCalled();
+      });
+
+      it('should not call native sync module function on unsupported OS', () => {
+        Platform.OS = 'GLaDOS' as any; // setting OS to something that won't match anything
+        const resp = syncGetter();
+        expect(resp).toEqual(false);
+        expect(syncNativeGetter).not.toHaveBeenCalled();
+      });
+
+      it('should not call native async module function on unsupported OS', async () => {
+        Platform.OS = 'GLaDOS' as any; // setting OS to something that won't match anything
+        const resp = await asyncGetter();
+        expect(resp).toEqual(false);
+        expect(asyncNativeGetter).not.toHaveBeenCalled();
+      });
+
+      it('should use memoized value if there exists one', async () => {
+        const resp = await asyncGetter();
+        const resp2 = syncGetter();
+        expect(resp).toBe(resp2);
+        expect(asyncNativeGetter).toHaveBeenCalled();
+        expect(syncNativeGetter).not.toHaveBeenCalled();
+      });
+    }
+  );
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -46,7 +46,6 @@ const stringFnNames = [
   'getMacAddress',
   'getSystemManufacturer',
   'getBuildId',
-  'getApiLevel',
   'getInstallerPackageName',
   'getDeviceName',
   'getUserAgent',
@@ -93,6 +92,7 @@ for (const name of booleanFnNames) {
 const numberFnNames = [
   'getUsedMemory',
   'getFontScale',
+  'getApiLevel',
   'getPreviewSdkInt',
   'getFirstInstallTime',
   'getLastUpdateTime',

--- a/src/internal/supported-platform-info.ts
+++ b/src/internal/supported-platform-info.ts
@@ -47,7 +47,7 @@ export function getSupportedPlatformInfoSync<T>({
   defaultValue,
   memoKey,
 }: GetSupportedPlatformInfoSyncParams<T>): T {
-  if (memoKey && memo[memoKey]) {
+  if (memoKey && memo[memoKey] != undefined) {
     return memo[memoKey];
   } else {
     const output = getSupportedFunction(supportedPlatforms, getter, () => defaultValue)();
@@ -68,7 +68,7 @@ export async function getSupportedPlatformInfoAsync<T>({
   defaultValue,
   memoKey,
 }: GetSupportedPlatformInfoAsyncParams<T>): Promise<T> {
-  if (memoKey && memo[memoKey]) {
+  if (memoKey && memo[memoKey] != undefined) {
     return memo[memoKey];
   } else {
     const output = await getSupportedFunction(supportedPlatforms, getter, () =>


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

re #1108
resolves  #1117

adds tests for the following groups of getters
- non-memoized boolean
- non-memoized number
- memoized array
- memoized boolean
- memoized number

fixes internal mock
- moves `getApiLevel` to `numberFnNames` (jest.setup.ts)

fixes a memoization bug related to falsy values in `getSupportedPlatformInfoFunctions`



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)

<hr />


The `non-memoized string` are a bit more complicated ('tedious' is probably a better word), so I'll have that in a later PR, or hopefully, others can take on some. :)
