### PR TITLE
feat(jest/react-native-device-info-mock): adding rest of mocks

### DIFF
--- a/jest/react-native-device-info-mock.js
+++ b/jest/react-native-device-info-mock.js
@@ -8,6 +8,10 @@ const [arrayFnAsync, arrayFnSync] = makeFns([]);
 const [booleanFnAsync, booleanFnSync] = makeFns(false);
 const [objectFnAsync, objectFnSync] = makeFns({});
 
+const numberAsyncHookResultHook = () => jest.fn(() => ({ loading: false, result: -1 }));
+const booleanAsyncHookResultHook = () => jest.fn(() => ({ loading: false, result: false }));
+const stringAsyncHookResultHook = () => jest.fn(() => ({ loading: false, result: 'unknown' }));
+
 const diMock = {
   getAndroidId: stringFnAsync(),
   getAndroidIdSync: stringFnSync(),
@@ -92,9 +96,13 @@ const diMock = {
   getUserAgentSync: stringFnSync(),
   hasSystemFeature: booleanFnAsync(),
   hasSystemFeatureSync: booleanFnSync(),
+  hasGms: booleanFnAsync(),
+  hasGmsSync: booleanFnSync(),
+  hasHms: booleanFnAsync(),
+  hasHmsSync: booleanFnSync(),
   isAirplaneMode: booleanFnAsync(),
   isAirplaneModeSync: booleanFnSync(),
-  isBatteryCharging: booleanFnAsync(),
+  isBatteryCharging: booleanFnAsync(),,
   isBatteryChargingSync: booleanFnSync(),
   isCameraPresent: booleanFnSync(),
   isCameraPresentSync: booleanFnSync(),
@@ -133,7 +141,15 @@ const diMock = {
   supported64BitAbisSync: arrayFnSync(),
   supportedAbis: arrayFnAsync(),
   supportedAbisSync: arrayFnSync(),
-  // TO DO: add hook mocks ?
+  useBatteryLevel: numberFnSync(),
+  useBatteryLevelIsLow: numberFnSync(),
+  usePowerState: objectFnSync(),
+  useIsHeadphonesConnected: booleanAsyncHookResultHook(),
+  useFirstInstallTime: numberAsyncHookResultHook(),
+  useDeviceName: stringAsyncHookResultHook(),
+  useHasSystemFeature: booleanAsyncHookResultHook(),
+  useIsEmulator: booleanAsyncHookResultHook(),
+  useManufacturer: stringAsyncHookResultHook(),
 };
 
 module.exports = diMock;


### PR DESCRIPTION
## Description

adds what I believe to be the remaining mocks for all the functions of this lib

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)

<hr />

@mikehardy this _should_ be it for mocks