### PR TITLE
Fix syntax error in mock definition

### DIFF
--- a/jest/react-native-device-info-mock.js
+++ b/jest/react-native-device-info-mock.js
@@ -102,7 +102,7 @@ const diMock = {
   hasHmsSync: booleanFnSync(),
   isAirplaneMode: booleanFnAsync(),
   isAirplaneModeSync: booleanFnSync(),
-  isBatteryCharging: booleanFnAsync(),,
+  isBatteryCharging: booleanFnAsync(),
   isBatteryChargingSync: booleanFnSync(),
   isCameraPresent: booleanFnSync(),
   isCameraPresentSync: booleanFnSync(),


### PR DESCRIPTION

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Just stumbled upon the error below when trying to start tests using 7.2.0:
```
SyntaxError: node_modules/react-native-device-info/jest/react-native-device-info-mock.js: Unexpected token (105:38)
```
Seems a trailing `,` made it into the code.

## Compatibility

Not required.

## Checklist

Not required.
