### PR TITLE
Added DeviceTypeDesktop to getDeviceType()

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -25,10 +25,11 @@ typedef NS_ENUM(NSInteger, DeviceType) {
     DeviceTypeHandset,
     DeviceTypeTablet,
     DeviceTypeTv,
+    DeviceTypeDesktop,
     DeviceTypeUnknown
 };
 
-#define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"unknown", nil]
+#define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"Desktop", @"unknown", nil]
 
 #if !(TARGET_OS_TV)
 @import CoreTelephony;
@@ -110,8 +111,9 @@ RCT_EXPORT_MODULE();
 {
     switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
         case UIUserInterfaceIdiomPhone: return DeviceTypeHandset;
-        case UIUserInterfaceIdiomPad: return DeviceTypeTablet;
+        case UIUserInterfaceIdiomPad: return TARGET_OS_MACCATALYST ? DeviceTypeDesktop : DeviceTypeTablet;
         case UIUserInterfaceIdiomTV: return DeviceTypeTv;
+        case UIUserInterfaceIdiomMac: return DeviceTypeDesktop;
         default: return DeviceTypeUnknown;
     }
 }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,6 +1,6 @@
 // @flow
 
-export type DeviceType = 'Handset' | 'Tablet' | 'Tv' | 'unknown';
+export type DeviceType = 'Handset' | 'Tablet' | 'Tv' | 'Desktop' | 'unknown';
 
 export type BatteryState = 'unknown' | 'unplugged' | 'charging' | 'full';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -558,21 +558,29 @@ export const [isAirplaneMode, isAirplaneModeSync] = getSupportedPlatformInfoFunc
   defaultValue: false,
 });
 
-export const getDeviceType = () =>
-  getSupportedPlatformInfoSync({
-    memoKey: 'deviceType',
-    supportedPlatforms: ['android', 'ios'],
-    defaultValue: 'unknown',
-    getter: () => RNDeviceInfo.deviceType,
-  });
+export const getDeviceType = () => {
 
-export const getDeviceTypeSync = () =>
-  getSupportedPlatformInfoSync({
+  if (Platform.OS === "windows") return "Desktop"
+
+  return getSupportedPlatformInfoSync({
     memoKey: 'deviceType',
     supportedPlatforms: ['android', 'ios'],
     defaultValue: 'unknown',
     getter: () => RNDeviceInfo.deviceType,
   });
+}
+
+export const getDeviceTypeSync = () => {
+
+  if (Platform.OS === "windows") return "Desktop"
+
+  return getSupportedPlatformInfoSync({
+    memoKey: 'deviceType',
+    supportedPlatforms: ['android', 'ios'],
+    defaultValue: 'unknown',
+    getter: () => RNDeviceInfo.deviceType,
+  });
+}
 
 export const [supportedAbis, supportedAbisSync] = getSupportedPlatformInfoFunctions({
   memoKey: '_supportedAbis',

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,4 +1,4 @@
-export type DeviceType = 'Handset' | 'Tablet' | 'Tv' | 'unknown';
+export type DeviceType = 'Handset' | 'Tablet' | 'Tv'  | 'Desktop' | 'unknown';
 
 export type BatteryState = 'unknown' | 'unplugged' | 'charging' | 'full';
 


### PR DESCRIPTION
As discussed here: https://github.com/react-native-device-info/react-native-device-info/issues/1127 and here: https://github.com/react-native-device-info/react-native-device-info/pull/1128

I've extended getDeviceType() to return "Desktop" on Catalyst and Windows apps. I'm not sure my solution for the windows version is desired, but it is tested and works. 