### PR TITLE
Fix import and export of types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # CHANGELOG
 
+## 8.0.1
+- Fix the exporting and importing of typings in ES6 build module
+
 ## 8.0.0
 
 - BREAKING(ios, xcode): Xcode 12 required with #1137. Use 7.3.2 if you must use outdated Xcode (#1151)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # CHANGELOG
 
 ## 8.0.1
-- Fix the exporting and importing of typings in ES6 build module
+- Fix the exporting and importing of typings in ES6 build module (#1164, thanks @diego-antonelli!)
 
 ## 8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # CHANGELOG
 
 ## 8.0.1
+
 - Fix the exporting and importing of typings in ES6 build module (#1164, thanks @diego-antonelli!)
 
 ## 8.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Get device information using react-native",
   "react-native": "src/index.ts",
   "types": "lib/typescript/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "8.0.1",
+  "version": "8.0.0",
   "description": "Get device information using react-native",
   "react-native": "src/index.ts",
   "types": "lib/typescript/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ import {
   getSupportedPlatformInfoAsync,
 } from './internal/supported-platform-info';
 import { DeviceInfoModule } from './internal/privateTypes';
-import type { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState } from './internal/types';
+import type {
+  AsyncHookResult,
+  DeviceType,
+  LocationProviderInfo,
+  PowerState,
+} from './internal/types';
 
 export const getUniqueId = () =>
   getSupportedPlatformInfoSync({

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   getSupportedPlatformInfoAsync,
 } from './internal/supported-platform-info';
 import { DeviceInfoModule } from './internal/privateTypes';
-import { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState } from './internal/types';
+import type { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState } from './internal/types';
 
 export const getUniqueId = () =>
   getSupportedPlatformInfoSync({
@@ -762,7 +762,7 @@ export function useManufacturer(): AsyncHookResult<string> {
   return useOnMount(getManufacturer, 'unknown');
 }
 
-export { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState };
+export type { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState };
 
 const deviceInfoModule: DeviceInfoModule = {
   getAndroidId,

--- a/src/internal/asyncHookWrappers.ts
+++ b/src/internal/asyncHookWrappers.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { NativeEventEmitter, NativeModules } from 'react-native';
-import { AsyncHookResult } from './types';
+import type { AsyncHookResult } from './types';
 
 /**
  * simple hook wrapper for async functions for 'on-mount / componentDidMount' that only need to fired once

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import { DeviceType, LocationProviderInfo, PowerState, AsyncHookResult } from './types';
+import type { DeviceType, LocationProviderInfo, PowerState, AsyncHookResult } from './types';
 
 export type NotchDevice = {
   brand: string;


### PR DESCRIPTION
## Description
In this PR I am fixing the way typing are being imported and re-exported.

Fixes #1162

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
