### PR TITLE
fix(ios, deviceType): support iOS-compiled app running on macOS

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -111,7 +111,11 @@ RCT_EXPORT_MODULE();
 {
     switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
         case UIUserInterfaceIdiomPhone: return DeviceTypeHandset;
-        case UIUserInterfaceIdiomPad: return TARGET_OS_MACCATALYST ? DeviceTypeDesktop : DeviceTypeTablet;
+        case UIUserInterfaceIdiomPad:
+            if (TARGET_OS_MACCATALYST || (@available(iOS 14.0, *) && [NSProcessInfo processInfo].isiOSAppOnMac)) {
+                return DeviceTypeDesktop;
+            }
+            return DeviceTypeTablet;
         case UIUserInterfaceIdiomTV: return DeviceTypeTv;
         case UIUserInterfaceIdiomMac: return DeviceTypeDesktop;
         default: return DeviceTypeUnknown;

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -112,8 +112,13 @@ RCT_EXPORT_MODULE();
     switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
         case UIUserInterfaceIdiomPhone: return DeviceTypeHandset;
         case UIUserInterfaceIdiomPad:
-            if (TARGET_OS_MACCATALYST || (@available(iOS 14.0, *) && [NSProcessInfo processInfo].isiOSAppOnMac)) {
+            if (TARGET_OS_MACCATALYST) {
                 return DeviceTypeDesktop;
+            }
+            if (@available(iOS 14.0, *)) {
+                if ([NSProcessInfo processInfo].isiOSAppOnMac) {
+                    return DeviceTypeDesktop;
+                }
             }
             return DeviceTypeTablet;
         case UIUserInterfaceIdiomTV: return DeviceTypeTv;


### PR DESCRIPTION
## Description

Expansion of PR #1137. That PR only checked if the app is an iOS app built for macOS not if it is an iOS app running on macOS. See https://developer.apple.com/documentation/xcode/creating_a_mac_version_of_your_ipad_app for details about how Catalyst is for creating a macOS native type package from an iOS app. #1137 uses a compile time define which is only present when creating a macOS version.

This adds a runtime check for running unmodified iOS apps on macOS, https://developer.apple.com/documentation/apple-silicon/running-your-ios-apps-on-macos . This allows proper detection of the underlying device type the iOS app is running on.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

* [ X] I have tested this on a device/simulator for each compatible OS