### PR TITLE
fix: get legacy serial number for old APIs (#1056)

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -688,6 +688,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
         if (getReactApplicationContext().checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
           return Build.getSerial();
         }
+      } else {
+        return Build.SERIAL;
       }
     } catch (Exception e) {
       // This is almost always a PermissionException. We will log it but return unknown


### PR DESCRIPTION
## Description

Following the disussion in #1056 this will allow users of old MDM devices like the Sunmi V2 and others to access serial numbers via their privileged system access permissions assigned by the MDM.

This shouldn't cause any problems as the Build.SERIAL will be populated with 'unkown' regardless of permissions.

Been using this via patch-package for months with live Sunmi V2 devices. Works like a charm.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
