### PR TITLE
ci(.github/workflows/release.yml): using `GH_TOKEN` as env and secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
         run: yarn ci:install
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn ci:shipit


### PR DESCRIPTION
## Description

Regarding the action, `Release` ,

replaces `GITHUB_TOKEN` environment variable w/ `GH_TOKEN` and updates the value to use the secret of the same name. `GITHUB_TOKEN` secret is a special secret that can't be set, so if you're writing into a protected branch, you'll need to add a PAT of a user that can write to said protected branches.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    N/A     |
| Windows |    N/A     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)

-- 

_it sucks that there isn't a good way to test actions locally_
