### PR TITLE
Add getcurrentappenvironment

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The example app in this repository shows an example usage of every single API, c
 | [getHost()](#gethost)                                             | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
 | [getIpAddress()](#getipaddress)                                   | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
 | [getIncremental()](#getincremental)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getInstallerPackageName()](#getinstallerpackagename)             | `Promise<string>`   |  ❌  |   ✅    |   ✅    | ❌  |
+| [getInstallerPackageName()](#getinstallerpackagename)             | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
 | [getInstallReferrer()](#getinstallreferrer)                       | `Promise<string>`   |  ❌  |   ✅    |   ✅    | ✅  |
 | [getInstanceId()](#getinstanceid)                                 | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
 | [getLastUpdateTime()](#getlastupdatetime)                         | `Promise<number>`   |  ❌  |   ✅    |   ❌    | ❌  |
@@ -615,7 +615,7 @@ DeviceInfo.getInstallerPackageName().then((installerPackageName) => {
   // Play Store: "com.android.vending"
   // Amazon: "com.amazon.venezia"
   // Samsung App Store: "com.sec.android.app.samsungapps"
-  // Developer, iOS: "unknown"
+  // iOS: "AppStore", "TestFlight", "Other"
 });
 ```
 

--- a/ios/RNDeviceInfo.xcodeproj/project.pbxproj
+++ b/ios/RNDeviceInfo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		663F51B9262200CA0023385E /* EnvironmentUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 663F51B8262200CA0023385E /* EnvironmentUtil.m */; };
 		76E65CA41D4CA143009B7AF1 /* DeviceUID.m in Sources */ = {isa = PBXBuildFile; fileRef = 76E65CA31D4CA143009B7AF1 /* DeviceUID.m */; };
 		BF770A3D1F6A3EEE007E5F09 /* DeviceUID.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 76E65CA21D4CA143009B7AF1 /* DeviceUID.h */; };
 		DA5891DC1BA9A9FC002B4DB2 /* RNDeviceInfo.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA5891DB1BA9A9FC002B4DB2 /* RNDeviceInfo.h */; };
@@ -43,6 +44,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		663F51B7262200520023385E /* EnvironmentUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnvironmentUtil.h; sourceTree = "<group>"; };
+		663F51B8262200CA0023385E /* EnvironmentUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EnvironmentUtil.m; sourceTree = "<group>"; };
 		76E65CA21D4CA143009B7AF1 /* DeviceUID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceUID.h; sourceTree = "<group>"; };
 		76E65CA31D4CA143009B7AF1 /* DeviceUID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceUID.m; sourceTree = "<group>"; };
 		DA5891D81BA9A9FC002B4DB2 /* libRNDeviceInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNDeviceInfo.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -93,6 +96,8 @@
 				76E65CA31D4CA143009B7AF1 /* DeviceUID.m */,
 				DA5891DB1BA9A9FC002B4DB2 /* RNDeviceInfo.h */,
 				DA5891DD1BA9A9FC002B4DB2 /* RNDeviceInfo.m */,
+				663F51B7262200520023385E /* EnvironmentUtil.h */,
+				663F51B8262200CA0023385E /* EnvironmentUtil.m */,
 			);
 			path = RNDeviceInfo;
 			sourceTree = "<group>";
@@ -177,6 +182,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				76E65CA41D4CA143009B7AF1 /* DeviceUID.m in Sources */,
+				663F51B9262200CA0023385E /* EnvironmentUtil.m in Sources */,
 				DA5891DE1BA9A9FC002B4DB2 /* RNDeviceInfo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/RNDeviceInfo/EnvironmentUtil.h
+++ b/ios/RNDeviceInfo/EnvironmentUtil.h
@@ -1,0 +1,39 @@
+//
+//  EnvironmentUtil.h
+//  RNDeviceInfo
+//
+//  Created by Dima Portenko on 10.04.2021.
+//  Copyright © 2021 Learnium. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ *  App environment
+ */
+typedef NS_ENUM(NSInteger, MSACEnvironment) {
+
+  /**
+   *  App has been downloaded from the AppStore.
+   */
+  MSACEnvironmentAppStore = 0,
+
+  /**
+   *  App has been downloaded from TestFlight.
+   */
+  MSACEnvironmentTestFlight = 1,
+
+  /**
+   *  App has been installed by some other mechanism.
+   *  This could be Ad-Hoc, Enterprise, etc.
+   */
+  MSACEnvironmentOther = 2
+};
+
+#define EnvironmentValues [NSArray arrayWithObjects: @"AppStore", @"TestFlight", @"Other", nil]
+
+@interface EnvironmentUtil : NSObject
+
++ (MSACEnvironment)currentAppEnvironment;
+
+@end

--- a/ios/RNDeviceInfo/EnvironmentUtil.m
+++ b/ios/RNDeviceInfo/EnvironmentUtil.m
@@ -1,0 +1,55 @@
+//
+//  EnvironmentUtil.m
+//  RNDeviceInfo
+//
+//  Created by Dima Portenko on 10.04.2021.
+//  Copyright © 2021 Learnium. All rights reserved.
+//
+
+#import "EnvironmentUtil.h"
+
+@implementation EnvironmentUtil
+
++ (MSACEnvironment)currentAppEnvironment {
+#if TARGET_OS_SIMULATOR || TARGET_OS_OSX || TARGET_OS_MACCATALYST
+  return MSACEnvironmentOther;
+#else
+
+  // MobilePovision profiles are a clear indicator for Ad-Hoc distribution.
+  if ([self hasEmbeddedMobileProvision]) {
+    return MSACEnvironmentOther;
+  }
+
+  /**
+   * TestFlight is only supported from iOS 8 onwards and as our deployment target is iOS 8, we don't have to do any checks for
+   * floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1).
+   */
+  if ([self isAppStoreReceiptSandbox]) {
+    return MSACEnvironmentTestFlight;
+  }
+
+  return MSACEnvironmentAppStore;
+#endif
+}
+
++ (BOOL)hasEmbeddedMobileProvision {
+  BOOL hasEmbeddedMobileProvision = !![[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
+  return hasEmbeddedMobileProvision;
+}
+
++ (BOOL)isAppStoreReceiptSandbox {
+#if TARGET_OS_SIMULATOR
+  return NO;
+#else
+  if (![NSBundle.mainBundle respondsToSelector:@selector(appStoreReceiptURL)]) {
+    return NO;
+  }
+  NSURL *appStoreReceiptURL = NSBundle.mainBundle.appStoreReceiptURL;
+  NSString *appStoreReceiptLastComponent = appStoreReceiptURL.lastPathComponent;
+
+  BOOL isSandboxReceipt = [appStoreReceiptLastComponent isEqualToString:@"sandboxReceipt"];
+  return isSandboxReceipt;
+#endif
+}
+
+@end

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -15,6 +15,7 @@
 #import "RNDeviceInfo.h"
 #import "DeviceUID.h"
 #import <DeviceCheck/DeviceCheck.h>
+#import "EnvironmentUtil.h"
 
 #if !(TARGET_OS_TV)
 #import <WebKit/WebKit.h>
@@ -792,6 +793,17 @@ RCT_EXPORT_METHOD(getAvailableLocationProviders:(RCTPromiseResolveBlock)resolve 
     resolve(self.getAvailableLocationProviders);
 }
 
+#pragma mark - Installer Package Name -
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getInstallerPackageNameSync) {
+    return [EnvironmentValues objectAtIndex:[EnvironmentUtil currentAppEnvironment]];
+}
+
+RCT_EXPORT_METHOD(getInstallerPackageName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve([EnvironmentValues objectAtIndex:[EnvironmentUtil currentAppEnvironment]]);
+}
+
+#pragma mark - dealloc -
 
 - (void)dealloc
 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export const [
   getInstallerPackageNameSync,
 ] = getSupportedPlatformInfoFunctions({
   memoKey: 'installerPackageName',
-  supportedPlatforms: ['android', 'windows'],
+  supportedPlatforms: ['android', 'windows', 'ios'],
   getter: () => RNDeviceInfo.getInstallerPackageName(),
   syncGetter: () => RNDeviceInfo.getInstallerPackageNameSync(),
   defaultValue: 'unknown',


### PR DESCRIPTION
## Description

Related #1216

add `getCurrentAppEnvironment` function for ios to determine whether app was downloaded from `AppStore`,`TestFlight` or `Other`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
