### PR TITLE
Adding mavenCentral() as jcenter() is shutting

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         repositories {
             mavenCentral()
             google()
-            jcenter()
         }
         def buildGradleVersion = ext.has('buildGradlePluginVersion') ? ext.get('buildGradlePluginVersion') : '4.1.1'
 
@@ -47,7 +46,6 @@ repositories {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"
     }
-    jcenter()
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     // module dependency in an application project.
     if (project == rootProject) {
         repositories {
+            mavenCentral()
             google()
             jcenter()
         }
@@ -40,6 +41,7 @@ android {
 }
 
 repositories {
+    mavenCentral()
     google()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
Adding mavenCentral() as jcenter() is shutting down

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #1220 
