### PR TITLE
Remove `pixel 3a` from devicesWithNotch.ts

### DIFF
--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -59,10 +59,6 @@ const devicesWithNotch: NotchDevice[] = [
   },
   {
     brand: 'google',
-    model: 'Pixel 3a',
-  },
-  {
-    brand: 'google',
     model: 'Pixel 4a',
   },
   {


### PR DESCRIPTION

## Description
[Pixel 3a](https://i.pcmag.com/imagery/reviews/01bJFrj1Us02CAmWTJAD9oe-21.1569474132.fit_scale.size_1028x578.jpg) does not have a notch.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
