### PR TITLE
Fix init if navigator is not defined

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -56,7 +56,7 @@ export const getUsedMemorySync = () => {
 };
 
 const init = async () => {
-  if (navigator.getBattery) {
+  if (typeof navigator !== 'undefined' && navigator.getBattery) {
     const battery = await navigator.getBattery();
 
     batteryCharging = battery.charging;


### PR DESCRIPTION
## Description

Add a check to see if navigator is defined. This fixes server side rendering in node where navigator is not defined. Since init is called when the module is required this causes an issue, even if not using any of the library methods.

## Compatibility

web only fix

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
