### PR TITLE
build(android): gradle plugin 4.2 ignores submodule gradle.properties

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
             mavenCentral()
             google()
         }
-        def buildGradleVersion = ext.has('buildGradlePluginVersion') ? ext.get('buildGradlePluginVersion') : '4.1.1'
+        def buildGradleVersion = ext.has('buildGradlePluginVersion') ? ext.get('buildGradlePluginVersion') : '4.2.0'
 
         dependencies {
             classpath "com.android.tools.build:gradle:$buildGradleVersion"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,0 @@
-android.useAndroidX=true


### PR DESCRIPTION
## Description

Android Gradle Plugin 4.2 ignore submodule gradle.properties, so this file is unused

remove it - tested it via removing it from the installed location in
node_modules/react-native-device-info/android/gradle.properties and it
was fine

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |         |
| Android |    ✅     |
| Windows |        |

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
