### PR TITLE
test(e2e, ios): buildcache-action for faster ios build

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -199,6 +199,8 @@ jobs:
           fetch-depth: 50
           submodules: recursive
 
+      - uses: mikehardy/buildcache-action@v1
+
       - uses: actions/setup-node@v2
         with:
           node-version: 14

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -296,7 +296,7 @@ PODS:
     - React-Core (= 0.63.4)
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
-  - RNDeviceInfo (7.4.0):
+  - RNDeviceInfo (8.1.3):
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -460,10 +460,10 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
-  RNDeviceInfo: 9538a884f862fe4aa0d7cead9f34e292d41ba8f6
+  RNDeviceInfo: 8d3a29207835f972bce883723882980143270d55
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 311cf87a4a33d759b7ec994ec3735e03d4ededbf
+PODFILE CHECKSUM: ccb89098e3295b4d89bff3324a768ef13f62c6ef
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "example:android": "cd example && yarn android",
     "example:android:build": "cd example/android && ./gradlew assembleDebug",
     "example:ios": "cd example && yarn ios",
-    "example:ios:build": "cd example/ios && xcodebuild -workspace example.xcworkspace -configuration Debug -scheme example -sdk iphonesimulator -arch x86_64 ONLY_ACTIVE_ARCH=YES | xcpretty",
+    "example:ios:build": "cd example/ios && xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace example.xcworkspace -configuration Debug -scheme example -sdk iphonesimulator -arch x86_64 ONLY_ACTIVE_ARCH=YES | xcpretty",
     "example:packager": "cd example && yarn start",
     "test": "jest",
     "precommit": "lint-staged && yarn analyze",


### PR DESCRIPTION

## Description

No issue logged - just integrating https://github.com/mikehardy/buildcache-action to speed things up in CI

I tested this on a machine that did not have buildcache installed via `yarn example:ios:build` to make sure it was backwards-compatible, it is

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |         |
| Windows |        |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
