### PR TITLE
Workaround for MAC address in android 11

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -320,7 +320,9 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
                 if (!addr.isLoopbackAddress()) {
                   int delim = sAddr.indexOf('%'); // drop ip6 zone suffix
                   String ipv6 =  delim<0 ? sAddr : sAddr.substring(0, delim);
-                  macAddress = getMacAddressFromIpv6(ipv6);
+                  if(ipv6.trim().length()>0){
+                    macAddress = getMacAddressFromIpv6(ipv6);
+                  }
                 }
               }
             }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Workaround for MAC address in android 11

Fixes #<issue-number>
https://github.com/react-native-device-info/react-native-device-info/issues/1248
<!-- OR, if you're implementing a new feature: -->

Updated getMacAddressSync method to add workaround for getting mac address in android 11

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [ X] I have tested this on a device/simulator for each compatible OS
