### PR TITLE
fix: make getUsedMemory more inline with iOS #895

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,9 @@ DeviceInfo.syncUniqueId().then((uniqueId) => {
 
 Gets the app memory usage, in bytes.
 
+⚠️ [A note from the Android docs.](https://developer.android.com/reference/android/app/ActivityManager#getProcessMemoryInfo(int%5B%5D))
+> Note: this method is only intended for debugging or building a user-facing process management UI.
+
 #### Examples
 
 ```js


### PR DESCRIPTION
## Description

My company is logging some metrics around memory usage and we've found there is a large discrepancy between iOS and Android. Android is about an order of magnitude lower. 

This is more inline with what's happening in iOS. Android was previously only getting the used bytes from the RN Runtime,
not the entire app.

The Android example app went from reporting ~4mb => ~80mb which is way more inline with what I'd expect.

**Do I need to bump the version in package json or will you take care of that on the next release?**

Fixes #895 

## Checklist

<!-- Check completed item: [X] -->

Some of the checklist items don't apply since I didn't change any APIs.

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
