### PR TITLE
fix(hasNotch): add Redmi Note 8 Pro to hasNotch list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [8.1.6]
+## [8.1.6](https://github.com/react-native-device-info/react-native-device-info/compare/v8.1.5...v8.1.6) (2021-08-03)
 
 - fix(hasNotch): fix missing Redme Note 8 Pro model name in devicesWithNotch.ts (@yevhenlv)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [8.1.6]
+
+- fix(hasNotch): fix missing Redme Note 8 Pro model name in devicesWithNotch.ts (@yevhenlv)
+
 ## [8.1.5](https://github.com/react-native-device-info/react-native-device-info/compare/v8.1.4...v8.1.5) (2021-07-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## [8.1.6](https://github.com/react-native-device-info/react-native-device-info/compare/v8.1.5...v8.1.6) (2021-08-03)
-
-- fix(hasNotch): fix missing Redme Note 8 Pro model name in devicesWithNotch.ts (@yevhenlv)
-
 ## [8.1.5](https://github.com/react-native-device-info/react-native-device-info/compare/v8.1.4...v8.1.5) (2021-07-30)
 
 

--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -291,6 +291,10 @@ const devicesWithNotch: NotchDevice[] = [
   },
   {
     brand: 'xiaomi',
+    model: 'Redmi Note 8 Pro',
+  },
+  {
+    brand: 'xiaomi',
     model: 'Mi A2 Lite',
   },
   {


### PR DESCRIPTION
## Description

Fixes #1275

Add Redmi Note 8 Pro to the list of devices with notch

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅   |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
