### PR TITLE
docs: add links for ipAdress deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ DeviceInfo.getHost().then((host) => {
 ### getIpAddress()
 
 **Deprecated** Gets the device current IP address. (of wifi only)
-Switch to @react-native-community/netinfo or react-native-network-info
+Switch to [react-native-netinfo/netinfo](https://github.com/react-native-netinfo/react-native-netinfo) or [react-native-network-info](https://github.com/pusherman/react-native-network-info)
 
 #### Examples
 


### PR DESCRIPTION
## Description
this PR add links to redirect links netinfo and network info library, like description say "deprecated method" i think it's a good idea redirect this libraries

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist

> ## Checklist
> * [ ]  I have tested this on a device/simulator for each compatible OS
> * [x]  I added the documentation in `README.md`
> * [ ]  I updated the typings files (`privateTypes.ts`, `types.ts`)
> * [ ]  I added a sample use of the API (`example/App.js`)

