### PR TITLE
fix(hasNotch): Missing device name for iPhone 13

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -245,10 +245,10 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone13,2": @"iPhone 12",
         @"iPhone13,3": @"iPhone 12 Pro",
         @"iPhone13,4": @"iPhone 12 Pro Max",
-	@"iPhone14,1": @"iPhone 12 mini",
-        @"iPhone14,2": @"iPhone 12",
-        @"iPhone14,3": @"iPhone 12 Pro",
-        @"iPhone14,4": @"iPhone 12 Pro Max",
+	@"iPhone14,1": @"iPhone 13 mini",
+        @"iPhone14,2": @"iPhone 13",
+        @"iPhone14,3": @"iPhone 13 Pro",
+        @"iPhone14,4": @"iPhone 13 Pro Max",
         @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
         @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
         @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -245,7 +245,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone13,2": @"iPhone 12",
         @"iPhone13,3": @"iPhone 12 Pro",
         @"iPhone13,4": @"iPhone 12 Pro Max",
-	@"iPhone14,1": @"iPhone 13 mini",
+	@"iPhone14,5": @"iPhone 13 mini",
         @"iPhone14,2": @"iPhone 13",
         @"iPhone14,3": @"iPhone 13 Pro",
         @"iPhone14,4": @"iPhone 13 Pro Max",

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -240,11 +240,15 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone12,1": @"iPhone 11",
         @"iPhone12,3": @"iPhone 11 Pro",
         @"iPhone12,5": @"iPhone 11 Pro Max",
+	@"iPhone12,8": @"iPhone SE", // (2nd Generation iPhone SE),
         @"iPhone13,1": @"iPhone 12 mini",
         @"iPhone13,2": @"iPhone 12",
         @"iPhone13,3": @"iPhone 12 Pro",
         @"iPhone13,4": @"iPhone 12 Pro Max",
-        @"iPhone12,8": @"iPhone SE", // (2nd Generation iPhone SE)
+	@"iPhone14,1": @"iPhone 12 mini",
+        @"iPhone14,2": @"iPhone 12",
+        @"iPhone14,3": @"iPhone 12 Pro",
+        @"iPhone14,4": @"iPhone 12 Pro Max",
         @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
         @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
         @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -245,10 +245,10 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone13,2": @"iPhone 12",
         @"iPhone13,3": @"iPhone 12 Pro",
         @"iPhone13,4": @"iPhone 12 Pro Max",
-	@"iPhone14,5": @"iPhone 13 mini",
-        @"iPhone14,2": @"iPhone 13",
-        @"iPhone14,3": @"iPhone 13 Pro",
-        @"iPhone14,4": @"iPhone 13 Pro Max",
+	@"iPhone14,4": @"iPhone 13 mini",
+	@"iPhone14,5": @"iPhone 13",
+        @"iPhone14,2": @"iPhone 13 Pro",
+        @"iPhone14,3": @"iPhone 13 Pro Max",
         @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
         @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
         @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Adds missing device name by code for iPhone 13 lineup. Relates to #1307

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |