### PR TITLE
docs: adding @schie as a contributor / code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global owners
-*	@mikehardy @machour @gantman @johan-dutoit
+*	@mikehardy @machour @gantman @johan-dutoit @schie

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
       "name": "Mike Hardy",
       "email": "github@mikehardy.net",
       "url": "https://github.com/mikehardy"
+    },
+    {
+      "name": "Dustin Schie",
+      "email": "github@schie.io",
+      "url": "https://github.com/schie"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
## Description
adds myself to `CODEOWNER` — I think this is how one automatically get assigned to review PRs. I don't get assigned/notified, so I don't see them.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    N/A     |
| Windows |    N/A     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
