### PR TITLE
revert(ios/rndeviceinfo): removing ios listener stubs

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -108,14 +108,6 @@ RCT_EXPORT_MODULE();
     hasListeners = NO;
 }
 
-RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {
-  // Keep: Required for RN built in Event Emitter Calls.
-}
-
-RCT_EXPORT_METHOD(removeListeners : (double)count) {
-  // Keep: Required for RN built in Event Emitter Calls.
-}
-
 - (DeviceType) getDeviceType
 {
     switch ([[UIDevice currentDevice] userInterfaceIdiom]) {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

removes added stubs to allow NativeEventEmitter to work on iOS again

resolves #1301

- tested on iOS and Android.
- tested on RN 0.64 and 0.65

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
