### PR TITLE
fix: replacing react native community

### DIFF
--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '10.0'
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-device-info.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-device-info/react-native-device-info.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React-Core'

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-* `git clone https://github.com/react-native-community/react-native-device-info.git`
+* `git clone https://github.com/react-native-device-info/react-native-device-info.git`
 * `cd react-native-device-info/example`
 * `yarn`
 

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-device-info": "github:react-native-community/react-native-device-info",
+    "react-native-device-info": "github:react-native-device-info/react-native-device-info",
     "react-native-windows": "^0.63.0-0"
   },
   "devDependencies": {

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -40,7 +40,7 @@ fi
 npx react-native init example
 pushd example
 npx react-native-windows-init --overwrite
-yarn add github:react-native-community/react-native-device-info
+yarn add github:react-native-device-info/react-native-device-info
 
 # Windows CI requires versions just a bit behind current in order to work #1155
 yarn add \

--- a/src/internal/nativeInterface.ts
+++ b/src/internal/nativeInterface.ts
@@ -17,11 +17,11 @@ if (!RNDeviceInfo) {
     // @ts-ignore
     Platform.OS === 'dom'
   ) {
-    throw new Error(`@react-native-community/react-native-device-info: NativeModule.RNDeviceInfo is null. To fix this issue try these steps:
+    throw new Error(`react-native-device-info: NativeModule.RNDeviceInfo is null. To fix this issue try these steps:
   • For react-native <= 0.59: Run \`react-native link react-native-device-info\` in the project root.
   • Rebuild and re-run the app.
   • If you are using CocoaPods on iOS, run \`pod install\` in the \`ios\` directory and then rebuild and re-run the app. You may also need to re-open Xcode to get the new pods.
-  If none of these fix the issue, please open an issue on the Github repository: https://github.com/react-native-community/react-native-device-info`);
+  If none of these fix the issue, please open an issue on the Github repository: https://github.com/react-native-device-info/react-native-device-info`);
   }
 }
 


### PR DESCRIPTION

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

- fix(internal/nativeinferface): fixing exception message when RNDeviceInfo is not found
- fix(rndeviceinfo.podspec): changing podspec git source
- docs(example): replacing usage of `react-native-community`
- chore(refresh-example): replacing old org

## TL;DR
replaces more usage of `react-native-community/react-native-device-info` with current org. This should be the rest of it.


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
