### PR TITLE
fix(android): gracefully handle SecurityException in getPhoneNumber

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -890,7 +890,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
                     (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && getReactApplicationContext().checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED))) {
       TelephonyManager telMgr = (TelephonyManager) getReactApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
       if (telMgr != null) {
-        return telMgr.getLine1Number();
+        try {
+          return telMgr.getLine1Number();
+        } catch (SecurityException e) {
+          System.err.println("getLine1Number called with permission, but threw anyway: " + e.getMessage());
+        }
       } else {
         System.err.println("Unable to getPhoneNumber. TelephonyManager was null");
       }


### PR DESCRIPTION

## Description

For some reason on targetSdkVersion30+ in some cases, you can have the appropriate
permission but still take a SecurityException when you attempt to call getLine1Number

This allows the method to gracefully fallback to "unknown" instead of crashing

This tested directly in an app I'm working on, I can reproduce a crash every time even though
when I probe it, I appear to have READ_SMS permission, right before I get a SecurityException saying...I don't have READ_SMS permission? It's quite odd.

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS

