### PR TITLE
fix(android, serial): Fix permission access to serial number

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -712,9 +712,9 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   public String getSerialNumberSync() {
     try {
       if (Build.VERSION.SDK_INT >= 26) {
-        if (getReactApplicationContext().checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
-          return Build.getSerial();
-        }
+        // There are a lot of conditions to access to getSerial api
+        // For details, see https://developer.android.com/reference/android/os/Build#getSerial()
+        return Build.getSerial();
       } else {
         return Build.SERIAL;
       }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -714,6 +714,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       if (Build.VERSION.SDK_INT >= 26) {
         // There are a lot of conditions to access to getSerial api
         // For details, see https://developer.android.com/reference/android/os/Build#getSerial()
+        // Rather than check each one, just try and rely on the catch below, for discussion on this approach, refer to
+        // https://github.com/react-native-device-info/react-native-device-info/issues/1320
         return Build.getSerial();
       } else {
         return Build.SERIAL;


### PR DESCRIPTION
## Description

Fixes #1320

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)

Nothing this is a minor fix ...