### PR TITLE
fix(useBatteryIsLow): return battery level only if low

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -713,16 +713,9 @@ export function useBatteryLevelIsLow(): number | null {
   const [batteryLevelIsLow, setBatteryLevelIsLow] = useState<number | null>(null);
 
   useEffect(() => {
-    const setInitialValue = async () => {
-      const initialValue: number = await getBatteryLevel();
-      setBatteryLevelIsLow(initialValue);
-    };
-
     const onChange = (level: number) => {
       setBatteryLevelIsLow(level);
     };
-
-    setInitialValue();
 
     const subscription = deviceInfoEmitter.addListener('RNDeviceInfo_batteryLevelIsLow', onChange);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -618,6 +618,13 @@ export function hasSystemFeatureSync(feature: string) {
   return false;
 }
 
+export function isLowBatteryLevel(level: number): boolean {
+  if (Platform.OS === 'android') {
+    return level < 0.15;
+  }
+  return level < 0.2;
+}
+
 export const [
   getSystemAvailableFeatures,
   getSystemAvailableFeaturesSync,
@@ -713,6 +720,13 @@ export function useBatteryLevelIsLow(): number | null {
   const [batteryLevelIsLow, setBatteryLevelIsLow] = useState<number | null>(null);
 
   useEffect(() => {
+    const setInitialValue = async () => {
+      const initialValue: number = await getBatteryLevel();
+      isLowBatteryLevel(initialValue) && setBatteryLevelIsLow(initialValue);
+    };
+
+    setInitialValue();
+
     const onChange = (level: number) => {
       setBatteryLevelIsLow(level);
     };


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes [#1346](https://github.com/react-native-device-info/react-native-device-info/issues/1346)

The hook `useBatteryIsLow` returns the current battery level on initial rendering - even if the current battery level is not considered as low (Android < 0.15, iOS < 0.20);

With removing the initial value from the useEffect hook on initial rendering, the returned value remains `null` until the listener `RNDeviceInfo_batteryLevelIsLow`  detects the first callback for a low battery status.


### Testing
On iOS simulator the battery level is always `-1`.
On Android emulator the battery level is always `1`.
At least for me.
I therefore tested it on an external physical device too. See the video in the linked ticket above. 

I did not find dedicated tests for the hooks. Let me know if I missed something.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅    |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)


