### PR TITLE
docs: Add possible ipados return value for getSystemName

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ Gets the device OS name.
 
 ```js
 let systemName = DeviceInfo.getSystemName();
-// iOS: "iOS" on newer iOS devices "iPhone OS" on older devices, including older iPad's.
+// iOS: "iOS" on newer iOS devices "iPhone OS" on older devices (including older iPad models), "iPadOS" for iPads using iPadOS 15.0 or higher.
 // Android: "Android"
 // Windows: ?
 ```


### PR DESCRIPTION
## Description

Fixes #1358

Since iPadOS 15.0 (or iOS 15.0) iPads return "iPadOS" as the system name.
I've added a line in docs that states that.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

* [ ] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
