### PR TITLE
ci: Do not run release and stale flows on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   release:
+    if: github.event.repository.fork == false
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,9 +7,8 @@ on:
 
 jobs:
   stale:
-
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/stale@v4
       with:


### PR DESCRIPTION
`release.yml` runs on push to master, and `stale.yml` runs on schedule. Both workflows should **not be run on forked repositories**. The credentials and permissions are missing, resulting in tons of failed runs (including email notifications):

> [fork/react-native-device-info] Run failed: Mark stale issues and pull requests - master (808c1b5)