### PR TITLE
Update stale workflow fork check

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,10 +7,11 @@ on:
 
 jobs:
   stale:
-    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4
+    - run: echo "IS_FORK=$(curl "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY" | jq -r .fork)" >> $GITHUB_ENV
+    - if: env.IS_FORK == 'false'
+      uses: actions/stale@v4
       with:
         operations-per-run: 100
         ascending: true
@@ -23,5 +24,3 @@ stake please comment and ping a maintainer to get this merged ASAP! Thanks for c
 utomatically'
         exempt-issue-labels: 'Keep Open'
         exempt-pr-labels: 'Keep Open'
-
-


### PR DESCRIPTION
Use a different way to check if the `stale` workflow was started in a forked repo.

It turned out the check added in #1361 does not work as expected for workflows with a `schedule` trigger.

The solution is described in this thread:
https://github.community/t/github-event-repository-fork-context-does-detect-forks-in-scheduled-jobs/185925/3
