### PR TITLE
Add Android 11 permissions for getPhoneNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,7 +770,8 @@ DeviceInfo.getPhoneNumber().then((phoneNumber) => {
 
 #### Android Permissions
 
-- [android.permission.READ_PHONE_STATE](https://developer.android.com/reference/android/Manifest.permission.html#READ_PHONE_STATE)
+- Android 10 and below: [android.permission.READ_PHONE_STATE](https://developer.android.com/reference/android/Manifest.permission.html#READ_PHONE_STATE)
+- Android 11 and up: [android.permission.READ_SMS](https://developer.android.com/reference/android/Manifest.permission.html#READ_SMS)
 
 #### Notes
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This is just adding the new permission to the README for `getPhoneNumber`. Note that I only added the permission that worked for me, there is another permission (linked in #1105) that worked for somebody else. But this was an old ticket, and this solution didn't work for me, so I did not add this permission. If we want, I can definitely add that one too!

Relates to #1364, #1105

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
