### PR TITLE
feat(ios): Add isMac() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The example app in this repository shows an example usage of every single API, c
 | [isPinOrFingerprintSet()](#ispinorfingerprintset)                 | `Promise<boolean>`  |  ✅  |   ✅    |   ✅    | ❌  |
 | [isTablet()](#istablet)                                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
 | [isTabletMode()](#istabletmode)                                   | `Promise<bool>`     |  ❌  |   ❌    |   ✅    | ❌  |
+| [isMac()](#ismac)                                              | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
 | [supported32BitAbis()](#supported32BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
 | [supported64BitAbis()](#supported64BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
 | [supportedAbis()](#supportedAbis)                                 | `Promise<string[]>` |  ✅  |   ✅    |   ❌    | ❌  |
@@ -1194,6 +1195,19 @@ Tells if the device is in tablet mode.
 
 ```js
 let isTabletMode = DeviceInfo.isTabletMode();
+// true
+```
+
+---
+
+### isMac()
+
+Tells if this is an iOS app running on a Mac with Apple Silicon.
+
+#### Examples
+
+```js
+let isMac = DeviceInfo.isMac();
 // true
 ```
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -197,6 +197,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("appVersion", appVersion);
     constants.put("buildNumber", buildNumber);
     constants.put("isTablet", deviceTypeResolver.isTablet());
+    constants.put("isMac", false);
     constants.put("appName", appName);
     constants.put("brand", Build.BRAND);
     constants.put("model", Build.MODEL);

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -64,6 +64,7 @@ RCT_EXPORT_MODULE();
          @"appVersion": [self getAppVersion],
          @"buildNumber": [self getBuildNumber],
          @"isTablet": @([self isTablet]),
+         @"isMac": @([self isMac]),
          @"appName": [self getAppName],
          @"brand": @"Apple",
          @"model": [self getModel],
@@ -401,6 +402,14 @@ RCT_EXPORT_METHOD(isEmulator:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromis
     } else {
         return NO;
     }
+}
+
+- (BOOL) isMac {
+    BOOL mac = NO;
+    if (@available(iOS 14.0, *)) {
+        mac = [[NSProcessInfo processInfo] isiOSAppOnMac];
+    }
+    return mac;
 }
 
 RCT_EXPORT_METHOD(getDeviceToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -145,6 +145,7 @@ declare module.exports: {
   isKeyboardConnectedSync: () => boolean,
   isTabletMode: () => Promise<boolean>,
   isTablet: () => boolean,
+  isMac: () => boolean,
   supported32BitAbis: () => Promise<string[]>,
   supported32BitAbisSync: () => string[],
   supported64BitAbis: () => Promise<string[]>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,6 +373,14 @@ export const isTablet = () =>
     getter: () => RNDeviceInfo.isTablet,
   });
 
+export const isMac = () =>
+  getSupportedPlatformInfoSync({
+      defaultValue: false,
+      supportedPlatforms: ['android', 'ios', 'windows'],
+      memoKey: 'mac',
+      getter: () => RNDeviceInfo.isMac,
+  });
+
 export const [isPinOrFingerprintSet, isPinOrFingerprintSetSync] = getSupportedPlatformInfoFunctions(
   {
     supportedPlatforms: ['android', 'ios', 'windows'],
@@ -919,6 +927,7 @@ const deviceInfoModule: DeviceInfoModule = {
   isKeyboardConnectedSync,
   isTabletMode,
   isTablet,
+  isMac,
   supported32BitAbis,
   supported32BitAbisSync,
   supported64BitAbis,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -17,6 +17,7 @@ interface NativeConstants {
   deviceId: string;
   deviceType: DeviceType;
   isTablet: boolean;
+  isMac: boolean;
   model: string;
   systemName: string;
   systemVersion: string;
@@ -174,6 +175,7 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   isLandscape: () => Promise<boolean>;
   isLandscapeSync: () => boolean;
   isTablet: () => boolean;
+  isMac: () => boolean;
   supported32BitAbis: () => Promise<string[]>;
   supported32BitAbisSync: () => string[];
   supported64BitAbis: () => Promise<string[]>;

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -40,6 +40,7 @@ namespace winrt::RNDeviceInfoCPP
       provider.Add(L"appVersion", getAppVersionSync());
       provider.Add(L"buildNumber", getBuildNumberSync());
       provider.Add(L"isTablet", isTabletSync());
+      provider.Add(L"isMac", false);
       provider.Add(L"appName", getAppNameSync());
       provider.Add(L"brand", getBrandSync());
       provider.Add(L"model", getModelSync());


### PR DESCRIPTION
## Description

Fixes #1371

Added a new function to check if we are running an iOS app on an Apple Silicon Mac. I also implemented it on Android and Windows, where it always returns false. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

* [ ] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
