### PR TITLE
add huawei p40 lite to devices with notches

### DIFF
--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -131,6 +131,10 @@ const devicesWithNotch: NotchDevice[] = [
   },
   {
     brand: 'Huawei',
+    model: 'JNY-LX1', // P40 Lite
+  },
+  {
+    brand: 'Huawei',
     model: 'Nova 3',
   },
   {


### PR DESCRIPTION
## Description

Fixes #1376

Added to `devicesWithNotch.ts`
```
{
    brand: 'Huawei',
    model: 'JNY-LX1', // P40 Lite
}
```

that allows `DeviceInfo.hasNotch()` with Huawei P40 Lite to be `true`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)

## Log output
```
 LOG  getBrand HUAWEI
 LOG  getModel JNY-LX1
 LOG  hasNotch true
```