### PR TITLE
feat(windows, supportedAbis): Add supportedAbis for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The example app in this repository shows an example usage of every single API, c
 | [isTabletMode()](#istabletmode)                                   | `Promise<bool>`     |  ❌  |   ❌    |   ✅    | ❌  |
 | [supported32BitAbis()](#supported32BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
 | [supported64BitAbis()](#supported64BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
-| [supportedAbis()](#supportedAbis)                                 | `Promise<string[]>` |  ✅  |   ✅    |   ❌    | ❌  |
+| [supportedAbis()](#supportedAbis)                                 | `Promise<string[]>` |  ✅  |   ✅    |   ✅    | ❌  |
 | [syncUniqueId()](#syncuniqueid)                                   | `Promise<string>`   |  ✅  |   ❌    |   ❌    | ❌  |
 
 ---
@@ -1323,7 +1323,7 @@ Returns a list of supported processor architecture version
 
 ```js
 DeviceInfo.supportedAbis().then((abis) => {
-  // [ "arm64 v8", "Intel x86-64h Haswell", "arm64-v8a", "armeabi-v7a", "armeabi" ]
+  // [ "arm64 v8", "Intel x86-64h Haswell", "arm64-v8a", "armeabi-v7a", "armeabi", "win_x86", "win_arm", "win_x64" ]
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { useCallback, useEffect, useState } from 'react';
 import { Dimensions, NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import { useOnEvent, useOnMount } from './internal/asyncHookWrappers';
@@ -582,7 +583,7 @@ export const getDeviceTypeSync = () => {
 
 export const [supportedAbis, supportedAbisSync] = getSupportedPlatformInfoFunctions({
   memoKey: '_supportedAbis',
-  supportedPlatforms: ['android', 'ios'],
+  supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.getSupportedAbis(),
   syncGetter: () => RNDeviceInfo.getSupportedAbisSync(),
   defaultValue: [] as string[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import { useCallback, useEffect, useState } from 'react';
 import { Dimensions, NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import { useOnEvent, useOnMount } from './internal/asyncHookWrappers';

--- a/src/internal/supported-platform-info.ts
+++ b/src/internal/supported-platform-info.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { Platform } from 'react-native';
 
 import {

--- a/src/internal/supported-platform-info.ts
+++ b/src/internal/supported-platform-info.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import { Platform } from 'react-native';
 
 import {

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -86,8 +86,8 @@ namespace winrt::RNDeviceInfoCPP
       }
     }
 
-    REACT_SYNC_METHOD(getSupportedABIsSync);
-    JSValueArray getSupportedABIsSync() noexcept
+    REACT_SYNC_METHOD(getSupportedAbisSync);
+    JSValueArray getSupportedAbisSync() noexcept
     {
         JSValueArray result = JSValueArray{};
         winrt::Windows::System::ProcessorArchitecture architecture = winrt::Windows::ApplicationModel::Package::Current().Id().Architecture();
@@ -96,19 +96,31 @@ namespace winrt::RNDeviceInfoCPP
         {
         case Windows::System::ProcessorArchitecture::X86:
             arch = "win_x86";
+            break;
         case Windows::System::ProcessorArchitecture::Arm:
             arch = "win_arm";
+            break;
         case Windows::System::ProcessorArchitecture::X64:
             arch = "win_x64";
+            break;
         case Windows::System::ProcessorArchitecture::Neutral:
             arch = "neutral";
+            break;
         case Windows::System::ProcessorArchitecture::Unknown:
             arch = "unknown";
+            break;
         default:
             arch = "???";
+            break;
         }
         result.push_back(arch);
         return result;
+    }
+    
+    REACT_METHOD(getSupportedAbis)
+    void getSupportedAbis(ReactPromise<JSValueArray> promise) noexcept
+    {
+        promise.Resolve(getSupportedAbisSync());
     }
 	
     REACT_SYNC_METHOD(getDeviceTypeSync);

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -44,7 +44,7 @@ namespace winrt::RNDeviceInfoCPP
       provider.Add(L"brand", getBrandSync());
       provider.Add(L"model", getModelSync());
       provider.Add(L"deviceType", getDeviceTypeSync());
-      provider.Add(L"supportedAbis", getSupportedABIsSync());
+      provider.Add(L"supportedAbis", getSupportedAbisSync());
     }
 
     bool isEmulatorHelper(std::string model)

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -90,7 +90,8 @@ namespace winrt::RNDeviceInfoCPP
     JSValueArray getSupportedAbisSync() noexcept
     {
         JSValueArray result = JSValueArray{};
-        winrt::Windows::System::ProcessorArchitecture architecture = winrt::Windows::ApplicationModel::Package::Current().Id().Architecture();
+        winrt::Windows::System::ProcessorArchitecture architecture = 
+            winrt::Windows::ApplicationModel::Package::Current().Id().Architecture();
         std::string arch;
         switch (architecture)
         {

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -44,6 +44,7 @@ namespace winrt::RNDeviceInfoCPP
       provider.Add(L"brand", getBrandSync());
       provider.Add(L"model", getModelSync());
       provider.Add(L"deviceType", getDeviceTypeSync());
+      provider.Add(L"supportedAbis", getSupportedABIsSync());
     }
 
     bool isEmulatorHelper(std::string model)
@@ -83,6 +84,31 @@ namespace winrt::RNDeviceInfoCPP
       {
         return false;
       }
+    }
+
+    REACT_SYNC_METHOD(getSupportedABIsSync);
+    JSValueArray getSupportedABIsSync() noexcept
+    {
+        JSValueArray result = JSValueArray{};
+        winrt::Windows::System::ProcessorArchitecture architecture = winrt::Windows::ApplicationModel::Package::Current().Id().Architecture();
+        std::string arch;
+        switch (architecture)
+        {
+        case Windows::System::ProcessorArchitecture::X86:
+            arch = "win_x86";
+        case Windows::System::ProcessorArchitecture::Arm:
+            arch = "win_arm";
+        case Windows::System::ProcessorArchitecture::X64:
+            arch = "win_x64";
+        case Windows::System::ProcessorArchitecture::Neutral:
+            arch = "neutral";
+        case Windows::System::ProcessorArchitecture::Unknown:
+            arch = "unknown";
+        default:
+            arch = "???";
+        }
+        result.push_back(arch);
+        return result;
     }
 	
     REACT_SYNC_METHOD(getDeviceTypeSync);

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -106,11 +106,8 @@ namespace winrt::RNDeviceInfoCPP
         case Windows::System::ProcessorArchitecture::Neutral:
             arch = "neutral";
             break;
-        case Windows::System::ProcessorArchitecture::Unknown:
-            arch = "unknown";
-            break;
         default:
-            arch = "???";
+            arch = "unknown";
             break;
         }
         result.push_back(arch);


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Added the getSupportedAbis methods for windows which allows a user to grab a windows device's current supported CPU architectures including x86, x64, and arm.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
