### PR TITLE
fix(ios): Missing device name for iPhone SE 3rd gen

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -241,7 +241,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone14,5": @"iPhone 13",
         @"iPhone14,2": @"iPhone 13 Pro",
         @"iPhone14,3": @"iPhone 13 Pro Max",
-	@"iPhone14,6": @"iPhone SE", // (3nd Generation iPhone SE),
+        @"iPhone14,6": @"iPhone SE", // (3nd Generation iPhone SE),
         @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
         @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
         @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -232,15 +232,16 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone12,1": @"iPhone 11",
         @"iPhone12,3": @"iPhone 11 Pro",
         @"iPhone12,5": @"iPhone 11 Pro Max",
-	@"iPhone12,8": @"iPhone SE", // (2nd Generation iPhone SE),
+        @"iPhone12,8": @"iPhone SE", // (2nd Generation iPhone SE),
         @"iPhone13,1": @"iPhone 12 mini",
         @"iPhone13,2": @"iPhone 12",
         @"iPhone13,3": @"iPhone 12 Pro",
         @"iPhone13,4": @"iPhone 12 Pro Max",
-	@"iPhone14,4": @"iPhone 13 mini",
-	@"iPhone14,5": @"iPhone 13",
+        @"iPhone14,4": @"iPhone 13 mini",
+        @"iPhone14,5": @"iPhone 13",
         @"iPhone14,2": @"iPhone 13 Pro",
         @"iPhone14,3": @"iPhone 13 Pro Max",
+	@"iPhone14,6": @"iPhone SE", // (3nd Generation iPhone SE),
         @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
         @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
         @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)


### PR DESCRIPTION
Adds missing device name by code for iPhone SE 3rd gen

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |