### PR TITLE
feat(ios): add getBrightness support for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The example app in this repository shows an example usage of every single API, c
 | [getUsedMemory()](#getusedmemory)                                 | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
 | [getUserAgent()](#getuseragent)                                   | `Promise<string>`   |  ✅  |   ✅    |   ❌    | ✅  |
 | [getVersion()](#getversion)                                       | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
+| [getBrightness()](#getBrightness)                                 | `Promise<number>`   |  ✅  |   ❌    |   ❌    | ❌  |
 | [hasGms()](#hasGms)                                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ❌  |
 | [hasHms()](#hasHms)                                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ❌  |
 | [hasNotch()](#hasNotch)                                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
@@ -1407,6 +1408,18 @@ DeviceInfo.getAvailableLocationProviders().then((providers) => {
   //   locationServicesEnabled: true
   //   significantLocationChangeMonitoringAvailable: true
   // }
+});
+```
+
+### getBrightness()
+
+Gets the current brightness level of the device's main screen. Currently iOS only. Returns a number between 0.0 and 1.0, inclusive.
+
+#### Examples
+
+```js
+DeviceInfo.getBrightness().then((brightness) => {
+  // iOS: 0.6
 });
 ```
 

--- a/example/App.js
+++ b/example/App.js
@@ -178,6 +178,7 @@ export default class App extends Component {
     deviceJSON.securityPatch = DeviceInfo.getSecurityPatchSync();
     deviceJSON.codename = DeviceInfo.getCodenameSync();
     deviceJSON.incremental = DeviceInfo.getIncrementalSync();
+    deviceJSON.brightness = DeviceInfo.getBrightnessSync();
     deviceJSON.supported32BitAbis = DeviceInfo.supported32BitAbisSync();
     deviceJSON.supported64BitAbis = DeviceInfo.supported64BitAbisSync();
     deviceJSON.hasGms = DeviceInfo.hasGmsSync();
@@ -247,6 +248,7 @@ export default class App extends Component {
       deviceJSON.securityPatch = await DeviceInfo.getSecurityPatch();
       deviceJSON.codename = await DeviceInfo.getCodename();
       deviceJSON.incremental = await DeviceInfo.getIncremental();
+      deviceJSON.brightness = await DeviceInfo.getBrightness();
       deviceJSON.supported32BitAbis = await DeviceInfo.supported32BitAbis();
       deviceJSON.supported64BitAbis = await DeviceInfo.supported64BitAbis();
       deviceJSON.hasGms = await DeviceInfo.hasGms();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -337,7 +337,7 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNDeviceInfo (8.4.9):
+  - RNDeviceInfo (8.5.1):
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -524,7 +524,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNDeviceInfo: 4944cf8787b9c5bffaf301fda68cc1a2ec003341
+  RNDeviceInfo: 8d4177859b062334835962799460528869a487fb
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -819,6 +819,22 @@ RCT_EXPORT_METHOD(getInstallerPackageName:(RCTPromiseResolveBlock)resolve reject
     resolve([EnvironmentValues objectAtIndex:[EnvironmentUtil currentAppEnvironment]]);
 }
 
+- (NSNumber *) getBrightness {
+#if !TARGET_OS_TV
+    return @([UIScreen mainScreen].brightness);
+#else
+    return @(-1);
+#endif
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getBrightnessSync) {
+    return self.getBrightness;
+}
+
+RCT_EXPORT_METHOD(getBrightness:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve(self.getBrightness);
+}
+
 #pragma mark - dealloc -
 
 - (void)dealloc

--- a/jest/react-native-device-info-mock.js
+++ b/jest/react-native-device-info-mock.js
@@ -132,6 +132,8 @@ const diMock = {
   getSystemVersion: stringFnSync(),
   getUniqueId: stringFnSync(),
   getVersion: stringFnSync(),
+  getBrightness: numberFnAsync(),
+  getBrightnessSync: numberFnSync(),
   hasNotch: booleanFnSync(),
   isLandscape: booleanFnAsync(),
   isLandscapeSync: booleanFnSync(),

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -118,6 +118,8 @@ declare module.exports: {
   getUserAgent: () => Promise<string>,
   getUserAgentSync: () => string,
   getVersion: () => string,
+  getBrightness: () => Promise<number>,
+  getBrightnessSync: () => number,
   hasNotch: () => boolean,
   hasSystemFeature: (feature: string) => Promise<boolean>,
   hasSystemFeature: (feature: string) => Promise<boolean>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -682,6 +682,13 @@ export const [
   defaultValue: {},
 });
 
+export const [getBrightness, getBrightnessSync] = getSupportedPlatformInfoFunctions({
+  supportedPlatforms: ['ios'],
+  getter: () => RNDeviceInfo.getBrightness(),
+  syncGetter: () => RNDeviceInfo.getBrightnessSync(),
+  defaultValue: -1,
+});
+
 export async function getDeviceToken() {
   if (Platform.OS === 'ios') {
     return RNDeviceInfo.getDeviceToken();
@@ -890,6 +897,8 @@ const deviceInfoModule: DeviceInfoModule = {
   getUserAgent,
   getUserAgentSync,
   getVersion,
+  getBrightness,
+  getBrightnessSync,
   hasGms,
   hasGmsSync,
   hasHms,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -118,6 +118,8 @@ interface ExposedNativeMethods {
   getUsedMemorySync: () => number;
   getUserAgent: () => Promise<string>;
   getUserAgentSync: () => string;
+  getBrightness: () => Promise<number>;
+  getBrightnessSync: () => number;
   hasGms: () => Promise<boolean>;
   hasGmsSync: () => boolean;
   hasHms: () => Promise<boolean>;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Added `getBrightness()` support for iOS to get the current brightness level of the device's main screen.

**Device test screenshot:**

<img width="320" src="https://user-images.githubusercontent.com/37284154/160291279-0d428097-dc14-4a65-a40d-87c38baada05.jpg" />

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
