### PR TITLE
fix(windows): addListener/removeListeners native stubs to quiet warnings

### DIFF
--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -822,6 +822,18 @@ namespace winrt::RNDeviceInfoCPP
         });
     }
 
+    REACT_METHOD(addListener);
+    void addListener(std::string) noexcept
+    {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    REACT_METHOD(removeListeners);
+    void removeListeners(int64_t) noexcept
+    {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
   };
 
 }


### PR DESCRIPTION
Doing windows equivalent for
https://github.com/react-native-device-info/react-native-device-info/pull/1289
https://github.com/react-native-device-info/react-native-device-info/issues/1288
https://github.com/react-native-device-info/react-native-device-info/commit/c518c32202c7af548ffd4bd797662d9493fed3bf

## Description

Fixes #1288

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
