### PR TITLE
fix(android, uniqueId)!: remove get uniqueId from startup constants

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -189,7 +189,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
     final Map<String, Object> constants = new HashMap<>();
 
-    constants.put("uniqueId", getUniqueIdSync());
+//     constants.put("uniqueId", getUniqueIdSync());
     constants.put("deviceId", Build.BOARD);
     constants.put("bundleId", getReactApplicationContext().getPackageName());
     constants.put("systemName", "Android");


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

accessing ANDROID_ID (the underlying system information behind getUniqueId) prior to getting consent from users violates policy in some app stores, this removes it from the startup constants so that users may be informed prior to accessing the information

Fixes #1427 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
