### PR TITLE
fix(android): remove uniqueId from constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,8 +1001,6 @@ DeviceInfo.getTotalMemory().then((totalMemory) => {
 
 ### getUniqueId()
 
-This is a constant and may be referenced directly
-
 Gets the device unique ID.
 On Android it is currently identical to `getAndroidId()` in this module.
 On iOS it uses the `DeviceUID` uid identifier.

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -189,7 +189,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
     final Map<String, Object> constants = new HashMap<>();
 
-    constants.put("uniqueId", getUniqueIdSync());
     constants.put("deviceId", Build.BOARD);
     constants.put("bundleId", getReactApplicationContext().getPackageName());
     constants.put("systemName", "Android");

--- a/example/App.js
+++ b/example/App.js
@@ -22,6 +22,7 @@ import {
   getManufacturer,
   getManufacturerSync,
   syncUniqueId,
+  getUniqueId,
   useBatteryLevel,
   useBatteryLevelIsLow,
   usePowerState,
@@ -107,7 +108,6 @@ export default class App extends Component {
   getConstantDeviceInfo() {
     let deviceJSON = {};
 
-    deviceJSON.uniqueId = DeviceInfo.getUniqueId();
     deviceJSON.deviceId = DeviceInfo.getDeviceId();
     deviceJSON.bundleId = DeviceInfo.getBundleId();
     deviceJSON.systemName = DeviceInfo.getSystemName();
@@ -127,6 +127,7 @@ export default class App extends Component {
   getSyncDeviceInfo() {
     let deviceJSON = {};
 
+    deviceJSON.uniqueId = getUniqueId();
     deviceJSON.manufacturer = getManufacturerSync();
     deviceJSON.buildId = DeviceInfo.getBuildIdSync();
     deviceJSON.isCameraPresent = DeviceInfo.isCameraPresentSync();

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -56,7 +56,6 @@ RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport {
     return @{
-         @"uniqueId": [self getUniqueId],
          @"deviceId": [self getDeviceId],
          @"bundleId": [self getBundleId],
          @"systemName": [self getSystemName],
@@ -364,7 +363,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getBuildIdSync) {
     return self.getBuildId;
 }
 
-- (NSString *) getUniqueId {
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getUniqueIdSync) {
     return [DeviceUID uid];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export const getUniqueId = () =>
     defaultValue: 'unknown',
     memoKey: 'uniqueId',
     supportedPlatforms: ['android', 'ios', 'windows'],
-    getter: () => RNDeviceInfo.uniqueId,
+    getter: () => RNDeviceInfo.getUniqueIdSync(),
   });
 
 let uniqueId: string;
@@ -918,6 +918,7 @@ const deviceInfoModule: DeviceInfoModule = {
   getType,
   getTypeSync,
   getUniqueId,
+  getUniqueIdSync: getUniqueId,
   getUsedMemory,
   getUsedMemorySync,
   getUserAgent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export const getUniqueId = () =>
     defaultValue: 'unknown',
     memoKey: 'uniqueId',
     supportedPlatforms: ['android', 'ios', 'windows'],
-    getter: () => RNDeviceInfo.getUniqueIdSync(),
+    getter: () => RNDeviceInfo.uniqueId || RNDeviceInfo.getUniqueIdSync(),
   });
 
 let uniqueId: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export const getUniqueId = () =>
     defaultValue: 'unknown',
     memoKey: 'uniqueId',
     supportedPlatforms: ['android', 'ios', 'windows'],
-    getter: () => RNDeviceInfo.uniqueId || RNDeviceInfo.getUniqueIdSync(),
+    getter: () => RNDeviceInfo.uniqueId ?? RNDeviceInfo.getUniqueIdSync(),
   });
 
 let uniqueId: string;

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -20,7 +20,6 @@ interface NativeConstants {
   model: string;
   systemName: string;
   systemVersion: string;
-  uniqueId: string;
 }
 
 interface HiddenNativeMethods {
@@ -114,6 +113,7 @@ interface ExposedNativeMethods {
   getTotalMemorySync: () => number;
   getType: () => Promise<string>;
   getTypeSync: () => string;
+  getUniqueIdSync: () => string;
   getUsedMemory: () => Promise<number>;
   getUsedMemorySync: () => number;
   getUserAgent: () => Promise<string>;

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -20,6 +20,7 @@ interface NativeConstants {
   model: string;
   systemName: string;
   systemVersion: string;
+  uniqueId?: string;
 }
 
 interface HiddenNativeMethods {

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -27,7 +27,6 @@ namespace winrt::RNDeviceInfoCPP
     REACT_CONSTANT_PROVIDER(constantsViaConstantsProvider);
     void constantsViaConstantsProvider(ReactConstantProvider& provider) noexcept
     {
-      provider.Add(L"uniqueId", getUniqueIdSync());
       provider.Add(L"deviceId", getDeviceIdSync());
       provider.Add(L"serialNumber", getSerialNumberSync());
       provider.Add(L"bundleId", getBundleIdSync());
@@ -49,7 +48,7 @@ namespace winrt::RNDeviceInfoCPP
 
     // What is a tablet is a debateable topic in Windows, as some windows devices can dynamically switch back and forth.
     // Also, see isTabletMode() instead of isTablet or deviceType.
-    // More refinement should be applied into this area as neccesary. 
+    // More refinement should be applied into this area as neccesary.
     bool isTabletHelper()
     {
       // AnalyticsInfo doesn't always return the values one might expect.
@@ -59,9 +58,9 @@ namespace winrt::RNDeviceInfoCPP
       // [Windows.Desktop, Windows.Mobile, Windows.Xbox, Windows.Holographic, Windows.Team, Windows.IoT]
       auto deviceForm = winrt::Windows::System::Profile::AnalyticsInfo::DeviceForm();
       auto deviceFamily = winrt::Windows::System::Profile::AnalyticsInfo::VersionInfo().DeviceFamily();
-      
+
       bool isTabletByAnalytics = deviceForm == L"Tablet" || deviceForm == L"Mobile" || deviceFamily == L"Windows.Mobile";
-      
+
       if (isTabletByAnalytics)
       {
         return true;
@@ -86,7 +85,7 @@ namespace winrt::RNDeviceInfoCPP
     JSValueArray getSupportedAbisSync() noexcept
     {
         JSValueArray result = JSValueArray{};
-        winrt::Windows::System::ProcessorArchitecture architecture = 
+        winrt::Windows::System::ProcessorArchitecture architecture =
             winrt::Windows::ApplicationModel::Package::Current().Id().Architecture();
         std::string arch;
         switch (architecture)
@@ -110,13 +109,13 @@ namespace winrt::RNDeviceInfoCPP
         result.push_back(arch);
         return result;
     }
-    
+
     REACT_METHOD(getSupportedAbis)
     void getSupportedAbis(ReactPromise<JSValueArray> promise) noexcept
     {
         promise.Resolve(getSupportedAbisSync());
     }
-	
+
     REACT_SYNC_METHOD(getDeviceTypeSync);
     std::string getDeviceTypeSync() noexcept
     {
@@ -686,7 +685,7 @@ namespace winrt::RNDeviceInfoCPP
     {
       promise.Resolve(getDeviceIdSync());
     }
-    
+
     REACT_SYNC_METHOD(getSerialNumberSync);
     std::string getSerialNumberSync() noexcept
     {

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -27,6 +27,7 @@ namespace winrt::RNDeviceInfoCPP
     REACT_CONSTANT_PROVIDER(constantsViaConstantsProvider);
     void constantsViaConstantsProvider(ReactConstantProvider& provider) noexcept
     {
+      provider.Add(L"uniqueId", getUniqueIdSync());
       provider.Add(L"deviceId", getDeviceIdSync());
       provider.Add(L"serialNumber", getSerialNumberSync());
       provider.Add(L"bundleId", getBundleIdSync());
@@ -48,7 +49,7 @@ namespace winrt::RNDeviceInfoCPP
 
     // What is a tablet is a debateable topic in Windows, as some windows devices can dynamically switch back and forth.
     // Also, see isTabletMode() instead of isTablet or deviceType.
-    // More refinement should be applied into this area as neccesary.
+    // More refinement should be applied into this area as neccesary. 
     bool isTabletHelper()
     {
       // AnalyticsInfo doesn't always return the values one might expect.
@@ -58,9 +59,9 @@ namespace winrt::RNDeviceInfoCPP
       // [Windows.Desktop, Windows.Mobile, Windows.Xbox, Windows.Holographic, Windows.Team, Windows.IoT]
       auto deviceForm = winrt::Windows::System::Profile::AnalyticsInfo::DeviceForm();
       auto deviceFamily = winrt::Windows::System::Profile::AnalyticsInfo::VersionInfo().DeviceFamily();
-
+      
       bool isTabletByAnalytics = deviceForm == L"Tablet" || deviceForm == L"Mobile" || deviceFamily == L"Windows.Mobile";
-
+      
       if (isTabletByAnalytics)
       {
         return true;
@@ -85,7 +86,7 @@ namespace winrt::RNDeviceInfoCPP
     JSValueArray getSupportedAbisSync() noexcept
     {
         JSValueArray result = JSValueArray{};
-        winrt::Windows::System::ProcessorArchitecture architecture =
+        winrt::Windows::System::ProcessorArchitecture architecture = 
             winrt::Windows::ApplicationModel::Package::Current().Id().Architecture();
         std::string arch;
         switch (architecture)
@@ -109,13 +110,13 @@ namespace winrt::RNDeviceInfoCPP
         result.push_back(arch);
         return result;
     }
-
+    
     REACT_METHOD(getSupportedAbis)
     void getSupportedAbis(ReactPromise<JSValueArray> promise) noexcept
     {
         promise.Resolve(getSupportedAbisSync());
     }
-
+	
     REACT_SYNC_METHOD(getDeviceTypeSync);
     std::string getDeviceTypeSync() noexcept
     {
@@ -685,7 +686,7 @@ namespace winrt::RNDeviceInfoCPP
     {
       promise.Resolve(getDeviceIdSync());
     }
-
+    
     REACT_SYNC_METHOD(getSerialNumberSync);
     std::string getSerialNumberSync() noexcept
     {


### PR DESCRIPTION
## Description

Obtaining uniqueId on Android has to be explicit in line with newly enforced Huawei and Google Play guidelines.
As an alternative, native method getUniqueIdSync has been implemented on all applicable platforms and is used in the current getUniqueId API method instead of constants.

Fixes #1427

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
