### PR TITLE
feat: Add device names for iPhone 14 family,  add check for dynamic island

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The example app in this repository shows an example usage of every single API, c
 | [hasGms()](#hasGms)                                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ❌  |
 | [hasHms()](#hasHms)                                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ❌  |
 | [hasNotch()](#hasNotch)                                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
+| [hasDynamicIsland()](#hasDynamicIsland)                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
 | [hasSystemFeature()](#hassystemfeaturefeature)                    | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ❌  |
 | [isAirplaneMode()](#isairplanemode)                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ✅  |
 | [isBatteryCharging()](#isbatterycharging)                         | `Promise<boolean>`  |  ✅  |   ✅    |   ✅    | ✅  |
@@ -1266,6 +1267,19 @@ Tells if the device has a notch.
 
 ```js
 let hasNotch = DeviceInfo.hasNotch();
+// true
+```
+
+---
+
+### hasDynamicIsland()
+
+Tells if the device has a dynamic island.
+
+#### Examples
+
+```js
+let hasDynamicIsland = DeviceInfo.hasDynamicIsland();
 // true
 ```
 

--- a/example/App.js
+++ b/example/App.js
@@ -140,6 +140,7 @@ export default class App extends Component {
     deviceJSON.isEmulator = DeviceInfo.isEmulatorSync();
     deviceJSON.fontScale = DeviceInfo.getFontScaleSync();
     deviceJSON.hasNotch = DeviceInfo.hasNotch();
+    deviceJSON.hasDynamicIsland = DeviceInfo.hasDynamicIsland();
     deviceJSON.firstInstallTime = DeviceInfo.getFirstInstallTimeSync();
     deviceJSON.lastUpdateTime = DeviceInfo.getLastUpdateTimeSync();
     deviceJSON.serialNumber = DeviceInfo.getSerialNumberSync();
@@ -212,6 +213,7 @@ export default class App extends Component {
       deviceJSON.isEmulator = await DeviceInfo.isEmulator();
       deviceJSON.fontScale = await DeviceInfo.getFontScale();
       deviceJSON.hasNotch = await DeviceInfo.hasNotch();
+      deviceJSON.hasDynamicIsland = await DeviceInfo.hasDynamicIsland();
       deviceJSON.firstInstallTime = await DeviceInfo.getFirstInstallTime();
       deviceJSON.lastUpdateTime = await DeviceInfo.getLastUpdateTime();
       deviceJSON.serialNumber = await DeviceInfo.getSerialNumber();

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -245,6 +245,10 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone14,2": @"iPhone 13 Pro",
         @"iPhone14,3": @"iPhone 13 Pro Max",
         @"iPhone14,6": @"iPhone SE", // (3nd Generation iPhone SE),
+        @"iPhone14,7": @"iPhone 14",
+        @"iPhone14,8": @"iPhone 14 Plus",
+        @"iPhone15,2": @"iPhone 14 Pro",
+        @"iPhone15,3": @"iPhone 14 Pro Max",
         @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
         @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
         @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -122,6 +122,7 @@ declare module.exports: {
   getBrightness: () => Promise<number>,
   getBrightnessSync: () => number,
   hasNotch: () => boolean,
+  hasDynamicIsland: () => boolean,
   hasSystemFeature: (feature: string) => Promise<boolean>,
   hasSystemFeature: (feature: string) => Promise<boolean>,
   hasSystemFeatureSync: (feature: string) => boolean,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Dimensions, NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import { useOnEvent, useOnMount } from './internal/asyncHookWrappers';
+import devicesWithDynamicIsland from "./internal/devicesWithDynamicIsland";
 import devicesWithNotch from './internal/devicesWithNotch';
 import RNDeviceInfo from './internal/nativeInterface';
 import {
@@ -395,6 +396,21 @@ export function hasNotch() {
       ) !== -1;
   }
   return notch;
+}
+
+let dynamicIsland: boolean;
+export function hasDynamicIsland() {
+  if (dynamicIsland === undefined) {
+    let _brand = getBrand();
+    let _model = getModel();
+    dynamicIsland =
+      devicesWithDynamicIsland.findIndex(
+        (item) =>
+          item.brand.toLowerCase() === _brand.toLowerCase() &&
+          item.model.toLowerCase() === _model.toLowerCase()
+      ) !== -1;
+  }
+  return dynamicIsland;
 }
 
 export const [hasGms, hasGmsSync] = getSupportedPlatformInfoFunctions({
@@ -931,6 +947,7 @@ const deviceInfoModule: DeviceInfoModule = {
   hasHms,
   hasHmsSync,
   hasNotch,
+  hasDynamicIsland,
   hasSystemFeature,
   hasSystemFeatureSync,
   isAirplaneMode,

--- a/src/internal/devicesWithDynamicIsland.ts
+++ b/src/internal/devicesWithDynamicIsland.ts
@@ -1,0 +1,14 @@
+import { NotchDevice } from './privateTypes';
+
+const devicesWithDynamicIsland: NotchDevice[] = [
+  {
+    brand: 'Apple',
+    model: 'iPhone 14 Pro',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 14 Pro Max',
+  },
+];
+
+export default devicesWithDynamicIsland;

--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -3,6 +3,14 @@ import { NotchDevice } from './privateTypes';
 const devicesWithNotch: NotchDevice[] = [
   {
     brand: 'Apple',
+    model: 'iPhone 14',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 14 Plus',
+  },
+  {
+    brand: 'Apple',
     model: 'iPhone 13 mini',
   },
   {

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -173,6 +173,7 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   getUniqueIdSync: () => string;
   getVersion: () => string;
   hasNotch: () => boolean;
+  hasDynamicIsland: () => boolean;
   hasSystemFeature: (feature: string) => Promise<boolean>;
   hasSystemFeatureSync: (feature: string) => boolean;
   isLandscape: () => Promise<boolean>;


### PR DESCRIPTION
## Description

- Added device names for new iPhone 14 family and updated `hasNotch` device list
- Added `hasDynamicIsland()` that allows to check if device has a [Dynamic Island](https://www.youtube.com/watch?v=WuEH265pUy4)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
