### PR TITLE
fix(hasNotch): add iPhone 14 Pro / Pro Max to devices with notch

### DIFF
--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -11,6 +11,14 @@ const devicesWithNotch: NotchDevice[] = [
   },
   {
     brand: 'Apple',
+    model: 'iPhone 14 Pro',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 14 Pro Max',
+  },
+  {
+    brand: 'Apple',
     model: 'iPhone 13 mini',
   },
   {


### PR DESCRIPTION
## Description

Add iPhone 14 Pro / iPhone 14 Pro Max to devices with notch

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |

## Checklist

<!-- Check completed item: [X] -->

* [ X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
