### PR TITLE
Fixes getDeviceName on Android when targeting API level 32 or newer

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -687,9 +687,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod(isBlockingSynchronousMethod = true)
   public String getDeviceNameSync() {
     try {
-      String bluetoothName = Settings.Secure.getString(getReactApplicationContext().getContentResolver(), "bluetooth_name");
-      if (bluetoothName != null) {
-        return bluetoothName;
+      if (Build.VERSION.SDK_INT <= 31) {
+        String bluetoothName = Settings.Secure.getString(getReactApplicationContext().getContentResolver(), "bluetooth_name");
+        if (bluetoothName != null) {
+          return bluetoothName;
+        }
       }
 
       if (Build.VERSION.SDK_INT >= 25) {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #1463

This fixes devices targeting API 32 or 33 from always returning 'unknown' due to an exception when fetching the bluetooth name.

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [N/A] I added the documentation in `README.md`
* [N/A] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [N/A] I added a sample use of the API (`example/App.js`)
