### PR TITLE
feat(android, instanceId): implement as UUIDv4 in shared prefs, w/fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you want to use Install Referrer tracking, you will need to add this config t
 ```
 
 If you are experiencing issues with hasGms() on your release apks, please add the following rule to your Proguard config
+
 ```
 -keep class com.google.android.gms.common.** {*;}
 ```
@@ -867,8 +868,11 @@ DeviceInfo.getSerialNumber().then((serialNumber) => {
   // Windows: ? (a serial number, if your app has the "capability smbios")
 });
 ```
+
 ## Notes
+
 ### capability smbios
+
 If you want to use this method in windows, you have to add smbios capability in your aplication. Please following this [documentation](https://docs.microsoft.com/en-us/windows/win32/sysinfo/access-smbios-information-from-a-universal-windows-app) for add the capability in your manifest file.
 
 ---
@@ -1012,7 +1016,7 @@ DeviceInfo.getTotalMemory().then((totalMemory) => {
 
 ### getUniqueId()
 
-*This identifier is considered sensitive information in some app stores (e.g. Huawei or Google Play) and may lead to your app being removed or rejected, if used without user consent or for unapproved purposes. Refer to store policies for more information (see notes below).*
+_This identifier is considered sensitive information in some app stores (e.g. Huawei or Google Play) and may lead to your app being removed or rejected, if used without user consent or for unapproved purposes. Refer to store policies for more information (see notes below)._
 
 Gets the device unique ID.
 On Android it is currently identical to `getAndroidId()` in this module.

--- a/README.md
+++ b/README.md
@@ -665,18 +665,24 @@ DeviceInfo.getInstallReferrer().then((installReferrer) => {
 
 ### getInstanceId()
 
-**Deprecated**
 Gets the application instance ID.
 
-Note that this requires the deprecated Firebase Instance Id package, so will likely return "unknown" if your dependencies are up to date and you remove the `firebase:iid` dependency as you should.
+This attempts to get an instance ID from these sources, in this order:
 
-In Android 8.0+ the "getUniqueId" methods are equivalent, as they resolve to ANDROID_ID which is scoped to the specific install of the app on a specific device by a specific user.
+- a value under key `instanceId` in SharedPreferences file `react-native-device-info`
+- Firebase IID (if `firebaseBomVersion` or `firebaseIidVersion` is defined in gradle ext - **deprecated**)
+- GMS IID (if `googlePlayServicesIidVersion` or `googlePlayServicesVersion` is defined in gradle ext - **deprecated**)
+- a random UUID generated from java.util.UUID.randomUUID() and stored in SharedPreferences
+
+If you are using the deprecated sources, the instance ID generated is stored in shared preferences so it will be stable during this major version of react-native-device-info.
+
+In a future version of react-native-device-info, the Firebase IID and GMS IID implementations will be removed, and all future values will be the value (if any) stored in SharedPreferences, or a new random UUID that will then be stored and used for that app installation in the future.
 
 #### Examples
 
 ```js
 DeviceInfo.getInstanceId().then((instanceId) => {
-  // Android: ?
+  // Android: da4e0245-5d6c-402a-a07c-0c5349f229e2
 });
 ```
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -164,7 +164,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     return NAME;
   }
 
-  public static SharedPreferences getRNDISharedPreferences(ReactApplicationContext context) {
+  public static SharedPreferences getRNDISharedPreferences(Context context) {
     return context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
   }
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -164,6 +164,10 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     return NAME;
   }
 
+  public static SharedPreferences getRNDISharedPreferences(ReactApplicationContext context) {
+    return context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
+  }
+
   @SuppressLint("MissingPermission")
   private WifiInfo getWifiInfo() {
     WifiManager manager = (WifiManager) getReactApplicationContext().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
@@ -637,7 +641,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   public String getInstallReferrerSync() {
-    SharedPreferences sharedPref = getReactApplicationContext().getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
+    SharedPreferences sharedPref = getRNDISharedPreferences(getReactApplicationContext());
     return sharedPref.getString("installReferrer", Build.UNKNOWN);
   }
   @ReactMethod

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext {        firebaseIidVersion = "21.1.0"
+    ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -74,7 +74,6 @@ sed -i -e $'s/react_native_post_install(installer)/react_native_post_install(ins
 rm -f ios/Podfile??
 
 # Patch the build.gradle directly to slice in our android play version
-sed -i -e 's/ext {$/ext {        firebaseIidVersion = "21.1.0"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        supportLibVersion = "1.7.0/' android/build.gradle
 sed -i -e 's/ext {$/ext {        mediaCompatVersion = "1.4.3"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        supportV4Version = "1.0.1"/' android/build.gradle


### PR DESCRIPTION
## Description

firebase IID and GMS IID are both long long deprecated and problematic now

We need to drop them but if anyone happens to be relying on them they will need to maintain
the current value

So start in this version by saving current values to shared preferences for stability

If Firebase IID and GMS IID are not available, start generating a UUIDv4 instance ID and saving it


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
