### PR TITLE
feat: add DisplayZoomed ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The example app in this repository shows an example usage of every single API, c
 | [isHeadphonesConnected()](#isHeadphonesConnected)                 | `Promise<boolean>`  |  ✅  |   ✅    |   ❌    | ❌  |
 | [isPinOrFingerprintSet()](#ispinorfingerprintset)                 | `Promise<boolean>`  |  ✅  |   ✅    |   ✅    | ❌  |
 | [isTablet()](#istablet)                                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
+| [isDisplayZoomed()](#isdisplayzoomed)                             | `boolean`           |  ✅  |   ❌    |   ❌    | ❌  |
 | [isTabletMode()](#istabletmode)                                   | `Promise<bool>`     |  ❌  |   ❌    |   ✅    | ❌  |
 | [supported32BitAbis()](#supported32BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
 | [supported64BitAbis()](#supported64BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
@@ -1206,6 +1207,19 @@ Tells if the device is a tablet.
 
 ```js
 let isTablet = DeviceInfo.isTablet();
+// true
+```
+
+---
+
+### isDisplayZoomed()
+
+Tells if the user changed Display Zoom to Zoomed
+
+#### Examples
+
+```js
+let isDisplayZoomed = DeviceInfo.isDisplayZoomed();
 // true
 ```
 

--- a/example/App.js
+++ b/example/App.js
@@ -117,6 +117,7 @@ export default class App extends Component {
     deviceJSON.readableVersion = DeviceInfo.getReadableVersion();
     deviceJSON.buildNumber = DeviceInfo.getBuildNumber();
     deviceJSON.isTablet = DeviceInfo.isTablet();
+    deviceJSON.isDisplayZoomed = DeviceInfo.isDisplayZoomed();
     deviceJSON.appName = DeviceInfo.getApplicationName();
     deviceJSON.brand = DeviceInfo.getBrand();
     deviceJSON.model = DeviceInfo.getModel();

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -67,6 +67,7 @@ RCT_EXPORT_MODULE();
          @"brand": @"Apple",
          @"model": [self getModel],
          @"deviceType": [self getDeviceTypeName],
+         @"isDisplayZoomed": @([self isDisplayZoomed]),
      };
 }
 
@@ -157,6 +158,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getDeviceNameSync) {
 
 RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     resolve(self.getDeviceName);
+}
+
+- (BOOL) isDisplayZoomed {
+    return [UIScreen mainScreen].scale != [UIScreen mainScreen].nativeScale;
 }
 
 - (NSString *) getAppName {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -153,6 +153,7 @@ declare module.exports: {
   isKeyboardConnectedSync: () => boolean,
   isTabletMode: () => Promise<boolean>,
   isTablet: () => boolean,
+  isDisplayZoomed: () => boolean,
   supported32BitAbis: () => Promise<string[]>,
   supported32BitAbisSync: () => string[],
   supported64BitAbis: () => Promise<string[]>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,6 +374,14 @@ export const isTablet = () =>
     getter: () => RNDeviceInfo.isTablet,
   });
 
+export const isDisplayZoomed = () =>
+  getSupportedPlatformInfoSync({
+    defaultValue: false,
+    supportedPlatforms: ['ios'],
+    memoKey: 'zoomed',
+    getter: () => RNDeviceInfo.isDisplayZoomed,
+  });
+
 export const [isPinOrFingerprintSet, isPinOrFingerprintSetSync] = getSupportedPlatformInfoFunctions(
   {
     supportedPlatforms: ['android', 'ios', 'windows'],
@@ -972,6 +980,7 @@ const DeviceInfo: DeviceInfoModule = {
   isKeyboardConnectedSync,
   isTabletMode,
   isTablet,
+  isDisplayZoomed,
   supported32BitAbis,
   supported32BitAbisSync,
   supported64BitAbis,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -17,6 +17,7 @@ interface NativeConstants {
   deviceId: string;
   deviceType: DeviceType;
   isTablet: boolean;
+  isDisplayZoomed: boolean;
   model: string;
   systemName: string;
   systemVersion: string;
@@ -179,6 +180,7 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   isLandscape: () => Promise<boolean>;
   isLandscapeSync: () => boolean;
   isTablet: () => boolean;
+  isDisplayZoomed: () => boolean;
   supported32BitAbis: () => Promise<string[]>;
   supported32BitAbisSync: () => string[];
   supported64BitAbis: () => Promise<string[]>;


### PR DESCRIPTION
add feat to check if the app has the zoomed feature enabled only for ios

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #1485

<!-- OR, if you're implementing a new feature: -->

Added `isDisplayZoomed()` that allows to check if the user has enabled the `zoomed` feature from IOS

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
