### PR TITLE
fix(ios, getCarrier): deal with carrierName deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,10 @@ DeviceInfo.getCarrier().then((carrier) => {
 });
 ```
 
+#### Notes
+
+> - According to [apple.developer.com](https://developer.apple.com/documentation/coretelephony/ctcarrier/1620313-carriername), getting the carrier name in iOS 16 is deprecated and returns "unknown" at some point in the future in iOS.
+
 ---
 
 ### getCodename()

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -329,6 +329,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 #else
     CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
     CTCarrier *carrier = [netinfo subscriberCellularProvider];
+    // carrierName is deprecated in iOS 16 and returns @"--" in the future.
     if (carrier.carrierName != nil && ![carrier.carrierName isEqualToString:@"--"]) {
         return carrier.carrierName;
     }

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -329,7 +329,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 #else
     CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
     CTCarrier *carrier = [netinfo subscriberCellularProvider];
-    if (carrier.carrierName != nil) {
+    if (carrier.carrierName != nil && ![carrier.carrierName isEqualToString:@"--"]) {
         return carrier.carrierName;
     }
     return @"unknown";


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This PR deals with `carrierName` [deprecation since iOS 16](https://developer.apple.com/documentation/coretelephony/ctcarrier/1620313-carriername).

According to the header file, `carrierName` returns "--" in the future.
If so, carrierName returns 'unknown' with this PR.

<img width="1004" alt="Screenshot 2023-02-02 at 22 56 07" src="https://user-images.githubusercontent.com/15065345/216344030-0ed9da48-39ad-44de-ae02-8b30d3bb8a88.png">


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
