### PR TITLE
getUserAgentSync: fix memoKey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,7 @@ export const getUserAgent = () =>
 
 export const getUserAgentSync = () =>
   getSupportedPlatformInfoSync({
-    memoKey: 'userAgent',
+    memoKey: 'userAgentSync',
     defaultValue: 'unknown',
     supportedPlatforms: ['android', 'web'],
     getter: () => RNDeviceInfo.getUserAgentSync(),


### PR DESCRIPTION
## Description

Fixes `getUserAgent` returning `unknown` when used with the `getUserAgentSync`

For example,

```javascript
  let userAgent = '' + Platform.select({
    android: DeviceInfo.getUserAgentSync(), // sync not supported by iOS - supportedPlatforms: ['android', 'web']
    default: await DeviceInfo.getUserAgent(),
  })
```

On `ios` it will return `unknown`

**The reason:**

`getUserAgent` and `getUserAgent` have same `memoKey`

https://github.com/react-native-device-info/react-native-device-info/blob/master/src/index.ts#L228
https://github.com/react-native-device-info/react-native-device-info/blob/master/src/index.ts#L236

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
