### PR TITLE
fix: add missing mock

### DIFF
--- a/jest/react-native-device-info-mock.js
+++ b/jest/react-native-device-info-mock.js
@@ -138,6 +138,7 @@ const diMock = {
   getBrightness: numberFnAsync(),
   getBrightnessSync: numberFnSync(),
   hasNotch: booleanFnSync(),
+  isDisplayZoomed: booleanFnSync(),  
   isLandscape: booleanFnAsync(),
   isLandscapeSync: booleanFnSync(),
   isMouseConnected: booleanFnAsync(),


### PR DESCRIPTION
Adds missing mock with the following config

```
import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock';
jest.mock('react-native-device-info', () => mockRNDeviceInfo);
```

<img width="630" alt="Screen Shot 2023-03-09 at 9 17 37 PM" src="https://user-images.githubusercontent.com/2933593/224230068-77d76bda-d9b3-4cda-892c-14ee1d357c49.png">
