### PR TITLE
feat(windows): implementation for useBatteryLevel & useBatteryLevelIsLow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1476,7 +1476,7 @@ DeviceInfo.getBrightness().then((brightness) => {
 
 ## Hooks & Events
 
-Currently iOS & Android only (web support for battery/charging-related APIs).
+Supported in Windows, iOS & Android (web support for battery/charging-related APIs).
 
 ### useBatteryLevel or RNDeviceInfo_batteryLevelDidChange
 
@@ -1505,13 +1505,14 @@ deviceInfoEmitter.addListener('RNDeviceInfo_batteryLevelDidChange', (level) => {
 
 ### useBatteryLevelIsLow or RNDeviceInfo_batteryLevelIsLow
 
-Fired when the battery drops is considered low
+Fired when the battery level is considered low (multiple times untill charged)
 
 | Platform | Percentage |
 | -------- | ---------- |
 | iOS      | 20         |
 | Android  | 15         |
 | Web      | 20         |
+| Windows  | 20         |
 
 #### Examples
 
@@ -1536,7 +1537,7 @@ deviceInfoEmitter.addListener('RNDeviceInfo_batteryLevelIsLow', (level) => {
 
 ### usePowerState or RNDeviceInfo_powerStateDidChange
 
-Fired when the battery state changes, for example when the device enters charging mode or is unplugged.
+Fired when the battery state changes or device enters in the power saving mode, for example when the device enters charging mode or is unplugged.
 
 #### Examples
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #1528 
1. add subscription to Battery.ReportUpdated in Initialize and send event RNDeviceInfo_batteryLevelDidChange with latest battery level
2. check for low battery condition of <20 and send event RNDeviceInfo_batteryLevelIsLow with latest battery level
3. update readme to reflect added functionality

<!-- OR, if you're implementing a new feature: -->


## Compatibility

| OS      | Existing | Implemented |
| ------- | :---------: | :---------: |
| iOS     |    ✅     |    ❌     |
| Android |    ✅     |    ❌     |
| Windows |    ❌     |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
