### PR TITLE
docs: Update README.md for getDeviceName

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ DeviceInfo.getDeviceName().then((deviceName) => {
 });
 ```
 
-This used to require the android.permission.BLUETOOTH but the new implementation in v3 does not need it. You may remove that from your AndroidManifest.xml if you had it for this API.
+This used to require the android.permission.BLUETOOTH but the new implementation in v3 does not need it. You may remove that from your AndroidManifest.xml if you had it for this API. iOS 16 and greater [require entitlements]([url](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_device-information_user-assigned-device-name)) to access user-defined device name, otherwise a generic value is returned (ie. 'iPad', 'iPhone')
 
 ---
 


### PR DESCRIPTION
getDeviceName only returns generic value unless app is given explicit entitlements to access user-defined device name.

## Description

Fixes [#1516](https://github.com/react-native-device-info/react-native-device-info/issues/1516)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist

* [ ] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
