### PR TITLE
feat(windows): Implemented gethost() for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The example app in this repository shows an example usage of every single API, c
 | [getFreeDiskStorage()](#getfreediskstorage)                       | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
 | [getFreeDiskStorageOld()](#getfreediskstorageold)                 | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
 | [getHardware()](#gethardware)                                     | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getHost()](#gethost)                                             | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
+| [getHost()](#gethost)                                             | `Promise<string>`   |  ❌  |   ✅    |   ✅    | ❌  |
 | [getIpAddress()](#getipaddress)                                   | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
 | [getIncremental()](#getincremental)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
 | [getInstallerPackageName()](#getinstallerpackagename)             | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
@@ -583,7 +583,8 @@ DeviceInfo.getHardware().then(hardware => {
 
 ### getHost()
 
-Hostname
+Gets the hostname for android and windows device.
+Note: Provides full system name in case of windows device.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ DeviceInfo.getHardware().then(hardware => {
 ### getHost()
 
 Gets the hostname for android and windows device.
-Note: Provides full system name in case of windows device.
+Note: Provides full system name in case of windows devices.
 
 #### Examples
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,7 +288,7 @@ export const [getHardware, getHardwareSync] = getSupportedPlatformInfoFunctions(
 
 export const [getHost, getHostSync] = getSupportedPlatformInfoFunctions({
   memoKey: 'host',
-  supportedPlatforms: ['android'],
+  supportedPlatforms: ['android', 'windows'],
   getter: () => RNDeviceInfo.getHost(),
   syncGetter: () => RNDeviceInfo.getHostSync(),
   defaultValue: 'unknown',

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -6,9 +6,13 @@
 #include <sstream>
 #include <chrono>
 #include <future>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Networking.Connectivity.h>
 
 using namespace winrt::Microsoft::ReactNative;
 using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::Networking;
+using namespace winrt::Windows::Networking::Connectivity;
 
 namespace winrt::RNDeviceInfoCPP
 {
@@ -531,6 +535,25 @@ namespace winrt::RNDeviceInfoCPP
     void getDeviceName(ReactPromise<std::string> promise) noexcept
     {
       promise.Resolve(getDeviceNameSync());
+    }
+
+    REACT_SYNC_METHOD(getHostSync);
+    std::string getHostSync() noexcept
+    {
+        try
+        {
+            return winrt::to_string(NetworkInformation::GetHostNames().GetAt(0).DisplayName());
+        }
+        catch (...)
+        {
+            return "unknown";
+        }
+    }
+
+    REACT_METHOD(getHost);
+    void getHost(ReactPromise<std::string> promise) noexcept
+    {
+        promise.Resolve(getHostSync());
     }
 
     REACT_SYNC_METHOD(getSystemVersionSync);


### PR DESCRIPTION
Added windows implementation of getHost(). Using this user can get full name of windows devices.

## Description

Fixes #1549

## Compatibility

| OS      | Existing| Implemented |
| -------  | :---------: | :---------: |
| iOS     |    ❌     |    ❌     |
| Android |    ✅    |    ❌     |
| Windows |    ❌ |    ✅  |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
