### PR TITLE
feat(windows): Implemented getHostNames() for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The example app in this repository shows an example usage of every single API, c
 | [getFreeDiskStorageOld()](#getfreediskstorageold)                 | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
 | [getHardware()](#gethardware)                                     | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
 | [getHost()](#gethost)                                             | `Promise<string>`   |  ❌  |   ✅    |   ✅    | ❌  |
+| [getHostNames()](#getHostNames)                                   | `Promise<string[]>` |  ❌  |   ❌    |   ✅    | ❌  |
 | [getIpAddress()](#getipaddress)                                   | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
 | [getIncremental()](#getincremental)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
 | [getInstallerPackageName()](#getinstallerpackagename)             | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |

--- a/example/App.js
+++ b/example/App.js
@@ -177,6 +177,7 @@ export default class App extends Component {
     deviceJSON.fingerprint = DeviceInfo.getFingerprintSync();
     deviceJSON.hardware = DeviceInfo.getHardwareSync();
     deviceJSON.host = DeviceInfo.getHostSync();
+    deviceJSON.hostNames = DeviceInfo.getHostNamesSync();
     deviceJSON.product = DeviceInfo.getProductSync();
     deviceJSON.tags = DeviceInfo.getTagsSync();
     deviceJSON.type = DeviceInfo.getTypeSync();
@@ -250,6 +251,7 @@ export default class App extends Component {
       deviceJSON.fingerprint = await DeviceInfo.getFingerprint();
       deviceJSON.hardware = await DeviceInfo.getHardware();
       deviceJSON.host = await DeviceInfo.getHost();
+      deviceJSON.hostNames = await DeviceInfo.getHostNames();
       deviceJSON.product = await DeviceInfo.getProduct();
       deviceJSON.tags = await DeviceInfo.getTags();
       deviceJSON.type = await DeviceInfo.getType();

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -66,6 +66,8 @@ declare module.exports: {
   getHardwareSync: () => string,
   getHost: () => Promise<string>,
   getHostSync: () => string,
+  getHostNames: () => Promise<string[]>;
+  getHostNamesSync: () => string[];
   getIncremental: () => Promise<string>,
   getIncrementalSync: () => string,
   getInstallerPackageName: () => Promise<string>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,6 +294,14 @@ export const [getHost, getHostSync] = getSupportedPlatformInfoFunctions({
   defaultValue: 'unknown',
 });
 
+export const [getHostNames, getHostNamesSync] = getSupportedPlatformInfoFunctions({
+  memoKey: 'hostNames',
+  supportedPlatforms: ['windows'],
+  getter: () => RNDeviceInfo.getHostNames(),
+  syncGetter: () => RNDeviceInfo.getHostNamesSync(),
+  defaultValue: [] as string[],
+});
+
 export const [getProduct, getProductSync] = getSupportedPlatformInfoFunctions({
   memoKey: 'product',
   supportedPlatforms: ['android'],
@@ -895,6 +903,8 @@ const DeviceInfo: DeviceInfoModule = {
   getHardwareSync,
   getHost,
   getHostSync,
+  getHostNames,
+  getHostNamesSync,
   getIncremental,
   getIncrementalSync,
   getInstallerPackageName,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -76,6 +76,8 @@ interface ExposedNativeMethods {
   getHardwareSync: () => string;
   getHost: () => Promise<string>;
   getHostSync: () => string;
+  getHostNames: () => Promise<string[]>;
+  getHostNamesSync: () => string[];
   getIncremental: () => Promise<string>;
   getIncrementalSync: () => string;
   getInstallerPackageName: () => Promise<string>;

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -857,6 +857,25 @@ namespace winrt::RNDeviceInfoCPP
         promise.Resolve(getHostSync());
     }
 
+    REACT_SYNC_METHOD(getHostNamesSync);
+    JSValueArray getHostNamesSync() noexcept
+    {
+         JSValueArray result = JSValueArray{};
+        winrt::Windows::Foundation::Collections::IVectorView<HostName> hostNames = NetworkInformation::GetHostNames();
+        for (HostName hostName : hostNames)
+        {
+            result.push_back(winrt::to_string(hostName.DisplayName()));
+        }
+
+        return result;
+    }
+    
+    REACT_METHOD(getHostNames)
+    void getHostNames(ReactPromise<JSValueArray> promise) noexcept
+    {
+        promise.Resolve(getHostNamesSync());
+    }
+
     REACT_METHOD(addListener);
     void addListener(std::string) noexcept
     {


### PR DESCRIPTION
Added windows implementation of getHostNames(). Using this user can get all host names of windows devices.

## Description

Fixes #1564 

## Compatibility

| OS      | Implemented |
| -------  | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ✅  |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
