### PR TITLE
feat(android/ios): Add event to monitor location services are turned on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -1673,6 +1673,27 @@ const { loading, result } = useIsHeadphonesConnected(); // { loading: true, resu
 
 ---
 
+### useIsLocationEnabled
+
+Tells if the device has location services turned off. 
+
+Required permission: `<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />`
+
+
+This hook subscribes to the event, `RNDeviceInfo_locationEnabledDidChange` , and updates the `result` field accordingly.
+
+#### Example
+
+```jsx
+import { useIsLocationEnabled } from 'react-native-device-info';
+
+const { loading, result } = useIsLocationEnabled(); // { loading: true, result: false}
+
+<Text>{loading ? 'loading...' : result}</Text>;
+```
+
+---
+
 ### useBrightness
 
 Gets the current brightness level of the device's main screen. Currently iOS only. Returns a number between 0.0 and 1.0, inclusive.

--- a/README.md
+++ b/README.md
@@ -1675,7 +1675,7 @@ const { loading, result } = useIsHeadphonesConnected(); // { loading: true, resu
 
 ### useIsLocationEnabled
 
-Tells if the device has location services turned off. 
+Tells if the device has location services are turned on/off. 
 
 Required permission: `<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />`
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -73,6 +73,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   private final DeviceIdResolver deviceIdResolver;
   private BroadcastReceiver receiver;
   private BroadcastReceiver headphoneConnectionReceiver;
+  private BroadcastReceiver locationServicesEnabledReceiver;
   private RNInstallReferrerClient installReferrerClient;
 
   private double mLastBatteryLevel = -1;
@@ -132,6 +133,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     };
 
     getReactApplicationContext().registerReceiver(receiver, filter);
+    initializeLocationServicesEnabledReceiver();
     initializeHeadphoneConnectionReceiver();
   }
 
@@ -149,6 +151,21 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     };
 
     getReactApplicationContext().registerReceiver(headphoneConnectionReceiver, filter);
+  }
+
+  private void initializeLocationServicesEnabledReceiver() {
+    IntentFilter filter = new IntentFilter();
+    filter.addAction(LocationManager.MODE_CHANGED_ACTION);
+
+    locationServicesEnabledReceiver = new BroadcastReceiver() {
+      @Override
+      public void onReceive(Context context, Intent intent) {
+        boolean isEnabled = isLocationEnabledSync();
+        sendEvent(getReactApplicationContext(), "RNDeviceInfo_locationEnabledDidChange", isEnabled);
+      }
+    };
+
+    getReactApplicationContext().registerReceiver(locationServicesEnabledReceiver, filter);
   }
 
 

--- a/example/App.js
+++ b/example/App.js
@@ -34,6 +34,7 @@ import {
   useIsEmulator,
   useIsHeadphonesConnected,
   useBrightness,
+  useIsLocationEnabled,
 } from 'react-native-device-info';
 
 const FunctionalComponent = () => {
@@ -46,6 +47,7 @@ const FunctionalComponent = () => {
   const hasSystemFeature = useHasSystemFeature('amazon.hardware.fire_tv');
   const isEmulator = useIsEmulator();
   const isHeadphonesConnected = useIsHeadphonesConnected();
+  const isLocationEnabled = useIsLocationEnabled();
   const brightness = useBrightness();
   const deviceJSON = {
     batteryLevel,
@@ -58,6 +60,7 @@ const FunctionalComponent = () => {
     isEmulator,
     isHeadphonesConnected,
     brightness,
+    isLocationEnabled,
   };
 
   return (
@@ -167,11 +170,13 @@ export default class App extends Component {
     deviceJSON.hasSystemFeature = DeviceInfo.hasSystemFeatureSync(
       'android.software.webview',
     );
-    deviceJSON.getSystemAvailableFeatures = DeviceInfo.getSystemAvailableFeaturesSync();
+    deviceJSON.getSystemAvailableFeatures =
+      DeviceInfo.getSystemAvailableFeaturesSync();
     deviceJSON.powerState = DeviceInfo.getPowerStateSync();
     deviceJSON.isLocationEnabled = DeviceInfo.isLocationEnabledSync();
     deviceJSON.headphones = DeviceInfo.isHeadphonesConnectedSync();
-    deviceJSON.getAvailableLocationProviders = DeviceInfo.getAvailableLocationProvidersSync();
+    deviceJSON.getAvailableLocationProviders =
+      DeviceInfo.getAvailableLocationProvidersSync();
     deviceJSON.bootloader = DeviceInfo.getBootloaderSync();
     deviceJSON.device = DeviceInfo.getDeviceSync();
     deviceJSON.display = DeviceInfo.getDisplaySync();
@@ -212,7 +217,8 @@ export default class App extends Component {
       deviceJSON.userAgent = await DeviceInfo.getUserAgent();
       deviceJSON.instanceId = await DeviceInfo.getInstanceId();
       deviceJSON.installReferrer = await DeviceInfo.getInstallReferrer();
-      deviceJSON.installerPackageName = await DeviceInfo.getInstallerPackageName();
+      deviceJSON.installerPackageName =
+        await DeviceInfo.getInstallerPackageName();
       deviceJSON.isEmulator = await DeviceInfo.isEmulator();
       deviceJSON.fontScale = await DeviceInfo.getFontScale();
       deviceJSON.hasNotch = await DeviceInfo.hasNotch();
@@ -229,23 +235,27 @@ export default class App extends Component {
       deviceJSON.totalMemory = await DeviceInfo.getTotalMemory();
       deviceJSON.maxMemory = await DeviceInfo.getMaxMemory();
       deviceJSON.totalDiskCapacity = await DeviceInfo.getTotalDiskCapacity();
-      deviceJSON.totalDiskCapacityOld = await DeviceInfo.getTotalDiskCapacityOld();
+      deviceJSON.totalDiskCapacityOld =
+        await DeviceInfo.getTotalDiskCapacityOld();
       deviceJSON.freeDiskStorage = await DeviceInfo.getFreeDiskStorage();
       deviceJSON.freeDiskStorageOld = await DeviceInfo.getFreeDiskStorageOld();
       deviceJSON.batteryLevel = await DeviceInfo.getBatteryLevel();
       deviceJSON.isLandscape = await DeviceInfo.isLandscape();
       deviceJSON.isAirplaneMode = await DeviceInfo.isAirplaneMode();
       deviceJSON.isBatteryCharging = await DeviceInfo.isBatteryCharging();
-      deviceJSON.isPinOrFingerprintSet = await DeviceInfo.isPinOrFingerprintSet();
+      deviceJSON.isPinOrFingerprintSet =
+        await DeviceInfo.isPinOrFingerprintSet();
       deviceJSON.supportedAbis = await DeviceInfo.supportedAbis();
       deviceJSON.hasSystemFeature = await DeviceInfo.hasSystemFeature(
         'android.software.webview',
       );
-      deviceJSON.getSystemAvailableFeatures = await DeviceInfo.getSystemAvailableFeatures();
+      deviceJSON.getSystemAvailableFeatures =
+        await DeviceInfo.getSystemAvailableFeatures();
       deviceJSON.powerState = await DeviceInfo.getPowerState();
       deviceJSON.isLocationEnabled = await DeviceInfo.isLocationEnabled();
       deviceJSON.headphones = await DeviceInfo.isHeadphonesConnected();
-      deviceJSON.getAvailableLocationProviders = await DeviceInfo.getAvailableLocationProviders();
+      deviceJSON.getAvailableLocationProviders =
+        await DeviceInfo.getAvailableLocationProviders();
       deviceJSON.bootloader = await DeviceInfo.getBootloader();
       deviceJSON.device = await DeviceInfo.getDevice();
       deviceJSON.display = await DeviceInfo.getDisplay();

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   package="com.example">
 
     <uses-permission android:name="android.permission.INTERNET" /><uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" /><uses-permission android:name="android.permission.ACCESS_WIFI_STATE" /><uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
       android:name=".MainApplication"

--- a/ios/RNDeviceInfo/RNDeviceInfo.h
+++ b/ios/RNDeviceInfo/RNDeviceInfo.h
@@ -13,8 +13,9 @@
 #import <React/RCTEventEmitter.h>
 #import <React/RCTLog.h>
 
-@interface RNDeviceInfo : RCTEventEmitter <RCTBridgeModule>
+@interface RNDeviceInfo : RCTEventEmitter <RCTBridgeModule, CLLocationManagerDelegate>
 
 @property (nonatomic) float lowBatteryThreshold;
+@property (nonatomic, strong) CLLocationManager *locationManager;
 
 @end

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Dimensions, NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import { useOnEvent, useOnMount } from './internal/asyncHookWrappers';
-import devicesWithDynamicIsland from "./internal/devicesWithDynamicIsland";
+import devicesWithDynamicIsland from './internal/devicesWithDynamicIsland';
 import devicesWithNotch from './internal/devicesWithNotch';
 import RNDeviceInfo from './internal/nativeInterface';
 import {
@@ -816,6 +816,10 @@ export function useIsHeadphonesConnected(): AsyncHookResult<boolean> {
   return useOnEvent('RNDeviceInfo_headphoneConnectionDidChange', isHeadphonesConnected, false);
 }
 
+export function useIsLocationEnabled(): AsyncHookResult<boolean> {
+  return useOnEvent('RNDeviceInfo_locationEnabledDidChange', isLocationEnabled, false);
+}
+
 export function useFirstInstallTime(): AsyncHookResult<number> {
   return useOnMount(getFirstInstallTime, -1);
 }
@@ -1016,6 +1020,7 @@ const DeviceInfo: DeviceInfoModule = {
   usePowerState,
   useManufacturer,
   useIsHeadphonesConnected,
+  useIsLocationEnabled,
   useBrightness,
 };
 

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -200,6 +200,7 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   usePowerState: () => Partial<PowerState>;
   useManufacturer: () => AsyncHookResult<string>;
   useIsHeadphonesConnected: () => AsyncHookResult<boolean>;
+  useIsLocationEnabled: () => AsyncHookResult<boolean>;
   useBrightness: () => number | null;
 }
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Partially covered the feature request #1035

<!-- OR, if you're implementing a new feature: -->

Added `useIsLocationEnabled()` hook to monitor whether the device has location services are turned on/off 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
