### PR TITLE
feat: add isTabletMode for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The example app in this repository shows an example usage of every single API, c
 | [isTablet()](#istablet)                                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
 | [isLowRamDevice()](#istablet)                                     | `boolean`           |  ❌  |   ✅    |   ❌    | ❌  |
 | [isDisplayZoomed()](#isdisplayzoomed)                             | `boolean`           |  ✅  |   ❌    |   ❌    | ❌  |
-| [isTabletMode()](#istabletmode)                                   | `Promise<bool>`     |  ❌  |   ❌    |   ✅    | ❌  |
+| [isTabletMode()](#istabletmode)                                   | `Promise<bool>`     |  ❌  |   ✅    |   ✅    | ❌  |
 | [supported32BitAbis()](#supported32BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
 | [supported64BitAbis()](#supported64BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
 | [supportedAbis()](#supportedAbis)                                 | `Promise<string[]>` |  ✅  |   ✅    |   ✅    | ❌  |
@@ -1258,8 +1258,9 @@ Tells if the device is in tablet mode.
 #### Examples
 
 ```js
-let isTabletMode = DeviceInfo.isTabletMode();
-// true
+DeviceInfo.isTabletMode.then((isTabletMode) => {
+  // true
+});
 ```
 
 ---

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -1033,4 +1033,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   public void getSupportedMediaTypeList(Promise promise) {
     promise.resolve(getSupportedMediaTypeListSync());
   }
+
+  // Some andorid devices with foldable screen can dynamically switch screen sizes.
+  // Different from "isTablet," it is obtained dynamically.
+   @ReactMethod
+  public void isTabletMode(Promise promise) {
+    promise.resolve(deviceTypeResolver.isTablet());
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -717,7 +717,7 @@ export const [getSupportedMediaTypeList, getSupportedMediaTypeListSync] = getSup
 
 export const isTabletMode = () =>
   getSupportedPlatformInfoAsync({
-    supportedPlatforms: ['windows'],
+    supportedPlatforms: ['android', 'windows'],
     getter: () => RNDeviceInfo.isTabletMode(),
     defaultValue: false,
   });


### PR DESCRIPTION
## Description

Added isTabletMode for Android that allows devices with foldable screen dynamically obtained mode when the screen sizes chagne.

## Compatibility

| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [√ ] I have tested this on a device/simulator for each compatible OS
* [√ ] I added the documentation in `README.md`
* [√ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [√] I added a sample use of the API (`example/App.js`)
