### PR TITLE
fix: wrap return value of useOnEvent in useMemo

### DIFF
--- a/src/internal/asyncHookWrappers.ts
+++ b/src/internal/asyncHookWrappers.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { NativeEventEmitter, NativeModules } from 'react-native';
 import type { AsyncHookResult } from './types';
 
@@ -55,5 +55,5 @@ export function useOnEvent<T>(
   }, [eventName]);
 
   // loading will only be true while getting the inital value. After that, it will always be false, but a new result may occur
-  return { loading, result };
+  return useMemo(() => ({ loading, result }), [loading, result]);
 }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description
Since `useOnEvent` returns an object which gets recreated on every render, this makes the value returned unstable and cause bug by retriggering useEffects when the value did not really change.

Assume the following:
```
import {useEffect, useState} from 'react';
import {useIsHeadphonesConnected} from 'react-native-device-info';
function App() {
  const isHeadphonesConnected = useIsHeadphonesConnected();
  const [_, setCounter] = useState(0);

  useEffect(() => {
    const intervalId = setInterval(() => {
      setCounter(prev => prev + 1);
    }, 1000);

    return () => {
      clearInterval(intervalId);
    };
  }, []);

  useEffect(() => {
    // some intensive work
    console.log('isHeadphonesConnected', isHeadphonesConnected);
  }, [isHeadphonesConnected]);
  return null;
}

export default App;
```

Since `useIsHeadphonesConnected` uses `useOnEvent` this will make the useffect with the `isHeadphonesConnected` to retrigger every time a rerender happens which cause unexpected behavior

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
