### PR TITLE
docs(README): update README for proguard rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn add react-native-device-info
 If you want to use Install Referrer tracking, you will need to add this config to your Proguard config
 
 ```
--keepclassmembers class com.android.installreferrer.api.** {
+-keep class com.android.installreferrer.api.** {
   *;
 }
 ```


### PR DESCRIPTION
In order to avoid Null Pointer Exception

## Description
When using this package with ProGuard enabled, on start-up of the app it crashes with the following error
```
java.lang.NullPointerException
	at com.android.installreferrer.api.b$b.onServiceConnected(SourceFile:24)
	at android.app.LoadedApk$ServiceDispatcher.doConnected(LoadedApk.java:2207)
	at android.app.LoadedApk$ServiceDispatcher$RunConnection.run(LoadedApk.java:2240)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at android.app.ActivityThread.main(ActivityThread.java:8248)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```

Fixes #1607

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
