### PR TITLE
feat: add visionos platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ While the asynchronous method `getUserAgent` is available on both platforms, `ge
 
 The example app in this repository shows an example usage of every single API, consult the example app if you have questions, and if you think you see a problem make sure you can reproduce it using the example app before reporting it, thank you.
 
-| Method                                                            | Return Type         |  iOS | Android | Windows | Web  | VisionOS |
+| Method                                                            | Return Type         |  iOS | Android | Windows | Web  | visionOS |
 | ----------------------------------------------------------------- | ------------------- | :--: | :-----: | :-----: | :-:  | :------: |
 | [getAndroidId()](#getandroidid)                                   | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
 | [getApiLevel()](#getapilevel)                                     | `Promise<number>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |

--- a/README.md
+++ b/README.md
@@ -119,90 +119,90 @@ While the asynchronous method `getUserAgent` is available on both platforms, `ge
 
 The example app in this repository shows an example usage of every single API, consult the example app if you have questions, and if you think you see a problem make sure you can reproduce it using the example app before reporting it, thank you.
 
-| Method                                                            | Return Type         |  iOS | Android | Windows | Web |
-| ----------------------------------------------------------------- | ------------------- | :--: | :-----: | :-----: | :-: |
-| [getAndroidId()](#getandroidid)                                   | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getApiLevel()](#getapilevel)                                     | `Promise<number>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getApplicationName()](#getapplicationname)                       | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getAvailableLocationProviders()](#getAvailableLocationProviders) | `Promise<Object>`   |  ✅  |   ✅    |   ❌    | ❌  |
-| [getBaseOs()](#getbaseOs)                                         | `Promise<string>`   |  ❌  |   ✅    |   ✅    | ✅  |
-| [getBuildId()](#getbuildid)                                       | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
-| [getBatteryLevel()](#getbatterylevel)                             | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
-| [getBootloader()](#getbootloader)                                 | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getBrand()](#getbrand)                                           | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getBuildNumber()](#getbuildnumber)                               | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getBundleId()](#getbundleid)                                     | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [isCameraPresent()](#iscamerapresent)                             | `Promise<boolean>`  |  ❌  |   ✅    |   ✅    | ✅  |
-| [getCarrier()](#getcarrier)                                       | `Promise<string>`   |  ✅  |   ✅    |   ❌    | ❌  |
-| [getCodename()](#getcodename)                                     | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getDevice()](#getdevice)                                         | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getDeviceId()](#getdeviceid)                                     | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getDeviceType()](#getDeviceType)                                 | `string`            |  ✅  |   ✅    |   ❌    | ❌  |
-| [getDisplay()](#getdisplay)                                       | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getDeviceName()](#getdevicename)                                 | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
-| [getDeviceToken()](#getdevicetoken)                               | `Promise<string>`   |  ✅  |   ❌    |   ❌    | ❌  |
-| [getFirstInstallTime()](#getfirstinstalltime)                     | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ❌  |
-| [getFingerprint()](#getfingerprint)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getFontScale()](#getfontscale)                                   | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ❌  |
-| [getFreeDiskStorage()](#getfreediskstorage)                       | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
-| [getFreeDiskStorageOld()](#getfreediskstorageold)                 | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
-| [getHardware()](#gethardware)                                     | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getHost()](#gethost)                                             | `Promise<string>`   |  ❌  |   ✅    |   ✅    | ❌  |
-| [getHostNames()](#getHostNames)                                   | `Promise<string[]>` |  ❌  |   ❌    |   ✅    | ❌  |
-| [getIpAddress()](#getipaddress)                                   | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
-| [getIncremental()](#getincremental)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getInstallerPackageName()](#getinstallerpackagename)             | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
-| [getInstallReferrer()](#getinstallreferrer)                       | `Promise<string>`   |  ❌  |   ✅    |   ✅    | ✅  |
-| [getInstanceId()](#getinstanceid)                                 | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getLastUpdateTime()](#getlastupdatetime)                         | `Promise<number>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getMacAddress()](#getmacaddress)                                 | `Promise<string>`   |  ✅  |   ✅    |   ❌    | ❌  |
-| [getManufacturer()](#getmanufacturer)                             | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
-| [getMaxMemory()](#getmaxmemory)                                   | `Promise<number>`   |  ❌  |   ✅    |   ✅    | ✅  |
-| [getModel()](#getmodel)                                           | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getPhoneNumber()](#getphonenumber)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getPowerState()](#getpowerstate)                                 | `Promise<object>`   |  ✅  |   ✅    |   ✅    | ✅  |
-| [getProduct()](#getproduct)                                       | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getPreviewSdkInt()](#getPreviewSdkInt)                           | `Promise<number>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getReadableVersion()](#getreadableversion)                       | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getSerialNumber()](#getserialnumber)                             | `Promise<string>`   |  ❌  |   ✅    |   ✅    | ❌  |
-| [getSecurityPatch()](#getsecuritypatch)                           | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getSystemAvailableFeatures()](#getSystemAvailableFeatures)       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
-| [getSystemName()](#getsystemname)                                 | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getSystemVersion()](#getsystemversion)                           | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getTags()](#gettags)                                             | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getType()](#gettype)                                             | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌  |
-| [getTotalDiskCapacity()](#gettotaldiskcapacity)                   | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
-| [getTotalDiskCapacityOld()](#gettotaldiskcapacityold)             | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
-| [getTotalMemory()](#gettotalmemory)                               | `Promise<number>`   |  ✅  |   ✅    |   ❌    | ✅  |
-| [getUniqueId()](#getuniqueid)                                     | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌  |
-| [getUsedMemory()](#getusedmemory)                                 | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅  |
-| [getUserAgent()](#getuseragent)                                   | `Promise<string>`   |  ✅  |   ✅    |   ❌    | ✅  |
-| [getUserAgentSync()](#getuseragent)                               | `string`            |  ❌  |   ✅    |   ❌    | ✅  |
-| [getVersion()](#getversion)                                       | `string`            |  ✅  |   ✅    |   ✅    | ❌  |
-| [getBrightness()](#getBrightness)                                 | `Promise<number>`   |  ✅  |   ❌    |   ❌    | ❌  |
-| [hasGms()](#hasGms)                                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ❌  |
-| [hasHms()](#hasHms)                                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ❌  |
-| [hasNotch()](#hasNotch)                                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
-| [hasDynamicIsland()](#hasDynamicIsland)                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
-| [hasSystemFeature()](#hassystemfeaturefeature)                    | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ❌  |
-| [isAirplaneMode()](#isairplanemode)                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | ✅  |
-| [isBatteryCharging()](#isbatterycharging)                         | `Promise<boolean>`  |  ✅  |   ✅    |   ✅    | ✅  |
-| [isEmulator()](#isemulator)                                       | `Promise<boolean>`  |  ✅  |   ✅    |   ✅    | ❌  |
-| [isKeyboardConnected()](#iskeyboardconnected)                     | `Promise<bool>`     |  ❌  |   ❌    |   ✅    | ❌  |
-| [isLandscape()](#isLandscape)                                     | `Promise<boolean>`  |  ✅  |   ✅    |   ✅    | ❌  |
-| [isLocationEnabled()](#isLocationEnabled)                         | `Promise<boolean>`  |  ✅  |   ✅    |   ❌    | ✅  |
-| [isMouseConnected()](#ismouseconneted)                            | `Promise<bool>`     |  ❌  |   ❌    |   ✅    | ❌  |
-| [isHeadphonesConnected()](#isHeadphonesConnected)                 | `Promise<boolean>`  |  ✅  |   ✅    |   ❌    | ❌  |
-| [isPinOrFingerprintSet()](#ispinorfingerprintset)                 | `Promise<boolean>`  |  ✅  |   ✅    |   ✅    | ❌  |
-| [isTablet()](#istablet)                                           | `boolean`           |  ✅  |   ✅    |   ✅    | ❌  |
-| [isLowRamDevice()](#istablet)                                     | `boolean`           |  ❌  |   ✅    |   ❌    | ❌  |
-| [isDisplayZoomed()](#isdisplayzoomed)                             | `boolean`           |  ✅  |   ❌    |   ❌    | ❌  |
-| [isTabletMode()](#istabletmode)                                   | `Promise<bool>`     |  ❌  |   ❌    |   ✅    | ❌  |
-| [supported32BitAbis()](#supported32BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
-| [supported64BitAbis()](#supported64BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
-| [supportedAbis()](#supportedAbis)                                 | `Promise<string[]>` |  ✅  |   ✅    |   ✅    | ❌  |
-| [syncUniqueId()](#syncuniqueid)                                   | `Promise<string>`   |  ✅  |   ❌    |   ❌    | ❌  |
-| [getSupportedMediaTypeList()](#getSupportedMediaTypeList)         | `Promise<string[]>` |  ❌  |   ✅    |   ❌    | ❌  |
+| Method                                                            | Return Type         |  iOS | Android | Windows | Web  | VisionOS |
+| ----------------------------------------------------------------- | ------------------- | :--: | :-----: | :-----: | :-:  | :------: |
+| [getAndroidId()](#getandroidid)                                   | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getApiLevel()](#getapilevel)                                     | `Promise<number>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getApplicationName()](#getapplicationname)                       | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getAvailableLocationProviders()](#getAvailableLocationProviders) | `Promise<Object>`   |  ✅  |   ✅    |   ❌     | ❌   |   ✅     |
+| [getBaseOs()](#getbaseOs)                                         | `Promise<string>`   |  ❌  |   ✅    |   ✅     | ✅   |   ❌     |
+| [getBuildId()](#getbuildid)                                       | `Promise<string>`   |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getBatteryLevel()](#getbatterylevel)                             | `Promise<number>`   |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
+| [getBootloader()](#getbootloader)                                 | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getBrand()](#getbrand)                                           | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getBuildNumber()](#getbuildnumber)                               | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getBundleId()](#getbundleid)                                     | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [isCameraPresent()](#iscamerapresent)                             | `Promise<boolean>`  |  ❌  |   ✅    |   ✅     | ✅   |   ❌     |
+| [getCarrier()](#getcarrier)                                       | `Promise<string>`   |  ✅  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getCodename()](#getcodename)                                     | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getDevice()](#getdevice)                                         | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getDeviceId()](#getdeviceid)                                     | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getDeviceType()](#getDeviceType)                                 | `string`            |  ✅  |   ✅    |   ❌     | ❌   |   ✅     |
+| [getDisplay()](#getdisplay)                                       | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getDeviceName()](#getdevicename)                                 | `Promise<string>`   |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getDeviceToken()](#getdevicetoken)                               | `Promise<string>`   |  ✅  |   ❌    |   ❌     | ❌   |   ✅     |
+| [getFirstInstallTime()](#getfirstinstalltime)                     | `Promise<number>`   |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getFingerprint()](#getfingerprint)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getFontScale()](#getfontscale)                                   | `Promise<number>`   |  ✅  |   ✅    |   ✅     | ❌   |   ❌     |
+| [getFreeDiskStorage()](#getfreediskstorage)                       | `Promise<number>`   |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
+| [getFreeDiskStorageOld()](#getfreediskstorageold)                 | `Promise<number>`   |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
+| [getHardware()](#gethardware)                                     | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getHost()](#gethost)                                             | `Promise<string>`   |  ❌  |   ✅    |   ✅     | ❌   |   ❌     |
+| [getHostNames()](#getHostNames)                                   | `Promise<string[]>` |  ❌  |   ❌    |   ✅     | ❌   |   ❌     |
+| [getIpAddress()](#getipaddress)                                   | `Promise<string>`   |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getIncremental()](#getincremental)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getInstallerPackageName()](#getinstallerpackagename)             | `Promise<string>`   |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getInstallReferrer()](#getinstallreferrer)                       | `Promise<string>`   |  ❌  |   ✅    |   ✅     | ✅   |   ❌     |
+| [getInstanceId()](#getinstanceid)                                 | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getLastUpdateTime()](#getlastupdatetime)                         | `Promise<number>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getMacAddress()](#getmacaddress)                                 | `Promise<string>`   |  ✅  |   ✅    |   ❌     | ❌   |   ✅     |
+| [getManufacturer()](#getmanufacturer)                             | `Promise<string>`   |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getMaxMemory()](#getmaxmemory)                                   | `Promise<number>`   |  ❌  |   ✅    |   ✅     | ✅   |   ❌     |
+| [getModel()](#getmodel)                                           | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getPhoneNumber()](#getphonenumber)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getPowerState()](#getpowerstate)                                 | `Promise<object>`   |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
+| [getProduct()](#getproduct)                                       | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getPreviewSdkInt()](#getPreviewSdkInt)                           | `Promise<number>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getReadableVersion()](#getreadableversion)                       | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getSerialNumber()](#getserialnumber)                             | `Promise<string>`   |  ❌  |   ✅    |   ✅     | ❌   |   ❌     |
+| [getSecurityPatch()](#getsecuritypatch)                           | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getSystemAvailableFeatures()](#getSystemAvailableFeatures)       | `Promise<string[]>` |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getSystemName()](#getsystemname)                                 | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getSystemVersion()](#getsystemversion)                           | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getTags()](#gettags)                                             | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getType()](#gettype)                                             | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getTotalDiskCapacity()](#gettotaldiskcapacity)                   | `Promise<number>`   |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
+| [getTotalDiskCapacityOld()](#gettotaldiskcapacityold)             | `Promise<number>`   |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
+| [getTotalMemory()](#gettotalmemory)                               | `Promise<number>`   |  ✅  |   ✅    |   ❌     | ✅   |   ✅     |
+| [getUniqueId()](#getuniqueid)                                     | `Promise<string>`   |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getUsedMemory()](#getusedmemory)                                 | `Promise<number>`   |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
+| [getUserAgent()](#getuseragent)                                   | `Promise<string>`   |  ✅  |   ✅    |   ❌     | ✅   |   ✅     |
+| [getUserAgentSync()](#getuseragent)                               | `string`            |  ❌  |   ✅    |   ❌     | ✅   |   ❌     |
+| [getVersion()](#getversion)                                       | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [getBrightness()](#getBrightness)                                 | `Promise<number>`   |  ✅  |   ❌    |   ❌     | ❌   |   ❌     |
+| [hasGms()](#hasGms)                                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [hasHms()](#hasHms)                                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [hasNotch()](#hasNotch)                                           | `boolean`           |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [hasDynamicIsland()](#hasDynamicIsland)                           | `boolean`           |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [hasSystemFeature()](#hassystemfeaturefeature)                    | `Promise<boolean>`  |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [isAirplaneMode()](#isairplanemode)                               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌     | ✅   |   ❌     |
+| [isBatteryCharging()](#isbatterycharging)                         | `Promise<boolean>`  |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
+| [isEmulator()](#isemulator)                                       | `Promise<boolean>`  |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [isKeyboardConnected()](#iskeyboardconnected)                     | `Promise<bool>`     |  ❌  |   ❌    |   ✅     | ❌   |   ❌     |
+| [isLandscape()](#isLandscape)                                     | `Promise<boolean>`  |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [isLocationEnabled()](#isLocationEnabled)                         | `Promise<boolean>`  |  ✅  |   ✅    |   ❌     | ✅   |   ✅     |
+| [isMouseConnected()](#ismouseconneted)                            | `Promise<bool>`     |  ❌  |   ❌    |   ✅     | ❌   |   ❌     |
+| [isHeadphonesConnected()](#isHeadphonesConnected)                 | `Promise<boolean>`  |  ✅  |   ✅    |   ❌     | ❌   |   ✅     |
+| [isPinOrFingerprintSet()](#ispinorfingerprintset)                 | `Promise<boolean>`  |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [isTablet()](#istablet)                                           | `boolean`           |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [isLowRamDevice()](#istablet)                                     | `boolean`           |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [isDisplayZoomed()](#isdisplayzoomed)                             | `boolean`           |  ✅  |   ❌    |   ❌     | ❌   |   ❌     |
+| [isTabletMode()](#istabletmode)                                   | `Promise<bool>`     |  ❌  |   ❌    |   ✅     | ❌   |   ❌     |
+| [supported32BitAbis()](#supported32BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [supported64BitAbis()](#supported64BitAbis)                       | `Promise<string[]>` |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [supportedAbis()](#supportedAbis)                                 | `Promise<string[]>` |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
+| [syncUniqueId()](#syncuniqueid)                                   | `Promise<string>`   |  ✅  |   ❌    |   ❌     | ❌   |   ✅     |
+| [getSupportedMediaTypeList()](#getSupportedMediaTypeList)         | `Promise<string[]>` |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
 
 ---
 
@@ -1354,6 +1354,7 @@ Returns the device's type as a string, which will be one of:
 - `Tv`
 - `Desktop`
 - `GamingConsole`
+- `Headset`
 - `unknown`
 
 #### Examples

--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -10,9 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['repository']['url']
-  s.platforms     = { :ios => "9.0", :visionos => "1.0" }
-  s.ios.deployment_target = '9.0'
-  s.tvos.deployment_target = '10.0'
+  s.platforms     = { :ios => "9.0", :visionos => "1.0", :tvos => "10.0"}
 
   s.source       = { :git => "https://github.com/react-native-device-info/react-native-device-info.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"

--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['repository']['url']
-  s.platform     = :ios, "9.0"
+  s.platforms     = { :ios => "9.0", :visionos => "1.0" }
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '10.0'
 

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -314,7 +314,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"AppleTV3,1": @"Apple TV", // Apple TV (3rd Generation)
         @"AppleTV3,2": @"Apple TV", // Apple TV (3rd Generation - Rev A)
         @"AppleTV5,3": @"Apple TV", // Apple TV (4th Generation)
-        @"AppleTV6,2": @"Apple TV 4K" // Apple TV 4K
+        @"AppleTV6,2": @"Apple TV 4K", // Apple TV 4K
         @"RealityDevice14,1": @"Apple Vision Pro" // Apple Vision Pro
     };
 }
@@ -368,7 +368,7 @@ RCT_EXPORT_METHOD(getCarrier:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromis
 }
 
 - (NSString *) getBuildId {
-#if TARGET_OS_TV || TARGET_OS_VISION
+#if TARGET_OS_TV
     return @"unknown";
 #else
     size_t bufferSize = 64;

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -33,11 +33,11 @@ typedef NS_ENUM(NSInteger, DeviceType) {
 
 #define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"Desktop", @"Headset", @"unknown", nil]
 
-#if !(TARGET_OS_TV) && !(TARGET_OS_VISION)
+#if (!(TARGET_OS_TV || TARGET_OS_VISION))
 @import CoreTelephony;
 #endif
 
-#if TARGET_OS_VISION && !TARGET_OS_TV
+#if !TARGET_OS_TV
 @import Darwin.sys.sysctl;
 #endif
 
@@ -691,9 +691,9 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTPromiseResolveBlock)resolve rejecter
                    "You need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
     }
 #endif
-#if RCT_DEV && TARGET_IPHONE_SIMULATOR && !TARGET_OS_TV && !TARGET_OS_VISION
+#if RCT_DEV && TARGET_IPHONE_SIMULATOR && !TARGET_OS_TV
     if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
-        RCTLogWarn(@"Battery state `unknown` and monitoring disabled, this is normal for simulators, tvOS & visionOS.");
+        RCTLogWarn(@"Battery state `unknown` and monitoring disabled, this is normal for simulators and tvOS.");
     }
 #endif
     float batteryLevel = self.getBatteryLevel;

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -22,6 +22,10 @@
 #import <LocalAuthentication/LocalAuthentication.h>
 #endif
 
+#if TARGET_OS_VISION
+#include <sys/xattr.h>
+#endif
+
 typedef NS_ENUM(NSInteger, DeviceType) {
     DeviceTypeHandset,
     DeviceTypeTablet,
@@ -32,7 +36,7 @@ typedef NS_ENUM(NSInteger, DeviceType) {
 
 #define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"Desktop", @"unknown", nil]
 
-#if !(TARGET_OS_TV)
+#if !(TARGET_OS_TV) && !(TARGET_OS_VISION)
 @import CoreTelephony;
 @import Darwin.sys.sysctl;
 #endif
@@ -94,10 +98,12 @@ RCT_EXPORT_MODULE();
                                                  selector:@selector(headphoneConnectionDidChange:)
                                                      name:AVAudioSessionRouteChangeNotification
                                                    object: [AVAudioSession sharedInstance]];
+        #if !TARGET_OS_VISION
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(brightnessDidChange:)
                                                      name:UIScreenBrightnessDidChangeNotification
                                                    object: nil];
+        #endif
 #endif
     }
 
@@ -161,7 +167,11 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 }
 
 - (BOOL) isDisplayZoomed {
-    return [UIScreen mainScreen].scale != [UIScreen mainScreen].nativeScale;
+    #if !TARGET_OS_VISION
+        return [UIScreen mainScreen].scale != [UIScreen mainScreen].nativeScale;
+    #else
+        return NO;
+    #endif
 }
 
 - (NSString *) getAppName {
@@ -333,7 +343,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 }
 
 - (NSString *) getCarrier {
-#if (TARGET_OS_TV || TARGET_OS_MACCATALYST)
+#if (TARGET_OS_TV || TARGET_OS_MACCATALYST || TARGET_OS_VISION)
     return @"unknown";
 #else
     CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
@@ -354,7 +364,7 @@ RCT_EXPORT_METHOD(getCarrier:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromis
 }
 
 - (NSString *) getBuildId {
-#if TARGET_OS_TV
+#if TARGET_OS_TV || TARGET_OS_VISION
     return @"unknown";
 #else
     size_t bufferSize = 64;
@@ -459,32 +469,35 @@ RCT_EXPORT_METHOD(getDeviceToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPr
 - (float) getFontScale {
     // Font scales based on font sizes from https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/
     float fontScale = 1.0;
-    UITraitCollection *traitCollection = [[UIScreen mainScreen] traitCollection];
 
-    // Shared application is unavailable in an app extension.
-    if (traitCollection) {
-        __block NSString *contentSize = nil;
-        RCTUnsafeExecuteOnMainQueueSync(^{
-            if (@available(iOS 10.0, tvOS 10.0, macCatalyst 13.0, *)) {
-                contentSize = traitCollection.preferredContentSizeCategory;
-            } else {
-                // if we can't get contentSize, we'll fall back to 1.0
-            }
-        });
+    #if !TARGET_OS_VISION
+        UITraitCollection *traitCollection = [[UIScreen mainScreen] traitCollection];
 
-        if ([contentSize isEqual: @"UICTContentSizeCategoryXS"]) fontScale = 0.82;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryS"]) fontScale = 0.88;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryM"]) fontScale = 0.95;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryL"]) fontScale = 1.0;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryXL"]) fontScale = 1.12;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryXXL"]) fontScale = 1.23;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryXXXL"]) fontScale = 1.35;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityM"]) fontScale = 1.64;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityL"]) fontScale = 1.95;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXL"]) fontScale = 2.35;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXXL"]) fontScale = 2.76;
-        else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXXXL"]) fontScale = 3.12;
-    }
+        // Shared application is unavailable in an app extension.
+        if (traitCollection) {
+            __block NSString *contentSize = nil;
+            RCTUnsafeExecuteOnMainQueueSync(^{
+                if (@available(iOS 10.0, tvOS 10.0, macCatalyst 13.0, *)) {
+                    contentSize = traitCollection.preferredContentSizeCategory;
+                } else {
+                    // if we can't get contentSize, we'll fall back to 1.0
+                }
+            });
+
+            if ([contentSize isEqual: @"UICTContentSizeCategoryXS"]) fontScale = 0.82;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryS"]) fontScale = 0.88;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryM"]) fontScale = 0.95;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryL"]) fontScale = 1.0;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryXL"]) fontScale = 1.12;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryXXL"]) fontScale = 1.23;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryXXXL"]) fontScale = 1.35;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityM"]) fontScale = 1.64;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityL"]) fontScale = 1.95;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXL"]) fontScale = 2.35;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXXL"]) fontScale = 2.76;
+            else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXXXL"]) fontScale = 3.12;
+        }
+    #endif
 
     return fontScale;
 }
@@ -851,7 +864,7 @@ RCT_EXPORT_METHOD(getInstallerPackageName:(RCTPromiseResolveBlock)resolve reject
 }
 
 - (NSNumber *) getBrightness {
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
     return @([UIScreen mainScreen].brightness);
 #else
     return @(-1);

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -22,22 +22,22 @@
 #import <LocalAuthentication/LocalAuthentication.h>
 #endif
 
-#if TARGET_OS_VISION
-#include <sys/xattr.h>
-#endif
-
 typedef NS_ENUM(NSInteger, DeviceType) {
     DeviceTypeHandset,
     DeviceTypeTablet,
     DeviceTypeTv,
     DeviceTypeDesktop,
+    DeviceTypeHeadset,
     DeviceTypeUnknown
 };
 
-#define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"Desktop", @"unknown", nil]
+#define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"Desktop", @"Headset", @"unknown", nil]
 
 #if !(TARGET_OS_TV) && !(TARGET_OS_VISION)
 @import CoreTelephony;
+#endif
+
+#if TARGET_OS_VISION && !TARGET_OS_TV
 @import Darwin.sys.sysctl;
 #endif
 
@@ -134,6 +134,7 @@ RCT_EXPORT_MODULE();
             return DeviceTypeTablet;
         case UIUserInterfaceIdiomTV: return DeviceTypeTv;
         case UIUserInterfaceIdiomMac: return DeviceTypeDesktop;
+        case UIUserInterfaceIdiomVision: return DeviceTypeHeadset;
         default: return DeviceTypeUnknown;
     }
 }
@@ -314,6 +315,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"AppleTV3,2": @"Apple TV", // Apple TV (3rd Generation - Rev A)
         @"AppleTV5,3": @"Apple TV", // Apple TV (4th Generation)
         @"AppleTV6,2": @"Apple TV 4K" // Apple TV 4K
+        @"RealityDevice14,1": @"Apple Vision Pro" // Apple Vision Pro
     };
 }
 
@@ -336,6 +338,8 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         return @"iPhone";
     } else if ([deviceId hasPrefix:@"AppleTV"]) {
         return @"Apple TV";
+    } else if ([deviceId hasPrefix:@"RealityDevice"]) {
+        return @"Apple Vision";
     }
 
     // If we could not even get a generic, it's unknown
@@ -687,9 +691,9 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTPromiseResolveBlock)resolve rejecter
                    "You need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
     }
 #endif
-#if RCT_DEV && TARGET_IPHONE_SIMULATOR && !TARGET_OS_TV
+#if RCT_DEV && TARGET_IPHONE_SIMULATOR && !TARGET_OS_TV && !TARGET_OS_VISION
     if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
-        RCTLogWarn(@"Battery state `unknown` and monitoring disabled, this is normal for simulators and tvOS.");
+        RCTLogWarn(@"Battery state `unknown` and monitoring disabled, this is normal for simulators, tvOS & visionOS.");
     }
 #endif
     float batteryLevel = self.getBatteryLevel;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Added `visionOS` platform support for the library.

<details>
<summary>1. Constant</summary>

![image](https://github.com/react-native-device-info/react-native-device-info/assets/21218732/01443665-01ae-4f90-a19c-edce9a958857)


</details>

<details>
<summary>2. Sync</summary>

![image](https://github.com/react-native-device-info/react-native-device-info/assets/21218732/7baeb1d3-6631-47af-97d8-4978068ddf6d)



</details>

<details>
<summary>3. Async</summary>

![image](https://github.com/react-native-device-info/react-native-device-info/assets/21218732/6702e6a2-bdba-4963-9be9-ce80d389cab3)


</details>

<details>
<summary>4. Hooks</summary>

![image](https://github.com/react-native-device-info/react-native-device-info/assets/21218732/6ed4c457-27fd-4432-b167-fb5092f26782)


</details>

## Help

- [ ] `getFontScale`: [preferredContentSizeCategory](https://developer.apple.com/documentation/uikit/uitraitcollection/1771748-traitcollectionwithpreferredcont?language=objc) is supported in visionOS, but I need help with finding what can we use besides UIScreen. This [section of blog](https://www.oskarkwasniewski.dev/blog/bringing-react-native-libraries-to-apple-vision-pro#usage-of-uiscreen) might help.

## References
- [Bringing React Native libraries to Apple Vision Pro](https://www.oskarkwasniewski.dev/blog/bringing-react-native-libraries-to-apple-vision-pro)
- https://callstack.github.io/react-native-visionos-docs/

<!-- OR, if you're implementing a new feature: -->

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
