### PR TITLE
fix(getDeviceType): add TARGET_OS_VISION guard for UIUserInterfaceIdiomVision

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -134,7 +134,9 @@ RCT_EXPORT_MODULE();
             return DeviceTypeTablet;
         case UIUserInterfaceIdiomTV: return DeviceTypeTv;
         case UIUserInterfaceIdiomMac: return DeviceTypeDesktop;
+    #if TARGET_OS_VISION
         case UIUserInterfaceIdiomVision: return DeviceTypeHeadset;
+    #endif
         default: return DeviceTypeUnknown;
     }
 }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

@UNIDY2002 raised a build failing issue [here](https://github.com/react-native-device-info/react-native-device-info/pull/1614#issuecomment-1962225526) due to visionos changes introduced by #1614.
I could also see same error in our github action ios build logs [here](https://github.com/react-native-device-info/react-native-device-info/actions/runs/8021357309/job/21913661609#step:12:299).

After referring to https://github.com/facebook/react-native/pull/42243/files#diff-ec1473a9d036148f566ce45864dfa02def7a9edc156862c9ea1ff8f374b59087 , I've added similar guardrail for our lib.

[`UIUserInterfaceIdiomVision`](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom/uiuserinterfaceidiomvision) is available only for iOS 17.0+.

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
