### PR TITLE
fix(android)!: removed deprecated getPhoneNumber - use react-native-sim-cards-manager if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ The example app in this repository shows an example usage of every single API, c
 | [getManufacturer()](#getmanufacturer)                               | `Promise<string>`   |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
 | [getMaxMemory()](#getmaxmemory)                                     | `Promise<number>`   |  ❌  |   ✅    |   ✅     | ✅   |   ❌     |
 | [getModel()](#getmodel)                                             | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
-| [getPhoneNumber()](#getphonenumber)                                 | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
 | [getPowerState()](#getpowerstate)                                   | `Promise<object>`   |  ✅  |   ✅    |   ✅     | ✅   |   ✅     |
 | [getProduct()](#getproduct)                                         | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
 | [getPreviewSdkInt()](#getPreviewSdkInt)                             | `Promise<number>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
@@ -783,25 +782,7 @@ let model = DeviceInfo.getModel();
 
 ### getPhoneNumber()
 
-Gets the device phone number.
-
-#### Examples
-
-```js
-DeviceInfo.getPhoneNumber().then((phoneNumber) => {
-  // Android: null return: no permission, empty string: unprogrammed or empty SIM1, e.g. "+15555215558": normal return value
-});
-```
-
-#### Android Permissions
-
-Please refer to the [Android docs](https://developer.android.com/about/versions/11/privacy/permissions#phone-numbers) for information about which permission you need, depending on which version of Android you are supporting. Read the note below for more information.
-
-#### Notes
-
-> This can return `undefined` in certain cases and should not be relied on. [SO entry on the subject](https://stackoverflow.com/questions/2480288/programmatically-obtain-the-phone-number-of-the-android-phone#answer-2480307).
-
-> If the above permissions do not work, you can try using `android.permission.READ_SMS`. However, this is not in the Android docs. If you are supporting Android 10 and below: [android.permission.READ_PHONE_STATE](https://developer.android.com/reference/android/Manifest.permission.html#READ_PHONE_STATE). If you are supporting Android 11 and up: [android.permission.READ_SMS](https://developer.android.com/reference/android/Manifest.permission.html#READ_SMS)
+The getPhoneNumber() has been removed. This method uses deprecated Android APIs. You can use react-native-sim-cards-manager to get the phone number.
 
 ---
 

--- a/__tests__/getters.test.ts
+++ b/__tests__/getters.test.ts
@@ -46,7 +46,6 @@ const nonMemoizedStringGetters = [
   'getMacAddress',
   'getIpAddress',
   'getDeviceName',
-  'getPhoneNumber',
   'getCarrier',
 ].map(makeTable);
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -954,29 +954,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getUserAgent(Promise p) { p.resolve(getUserAgentSync()); }
 
-  @SuppressLint({"HardwareIds", "MissingPermission"})
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public String getPhoneNumberSync() {
-    if (getReactApplicationContext() != null &&
-            (getReactApplicationContext().checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
-                    (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && getReactApplicationContext().checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED) ||
-                    (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && getReactApplicationContext().checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED))) {
-      TelephonyManager telMgr = (TelephonyManager) getReactApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
-      if (telMgr != null) {
-        try {
-          return telMgr.getLine1Number();
-        } catch (SecurityException e) {
-          System.err.println("getLine1Number called with permission, but threw anyway: " + e.getMessage());
-        }
-      } else {
-        System.err.println("Unable to getPhoneNumber. TelephonyManager was null");
-      }
-    }
-    return "unknown";
-  }
-  @ReactMethod
-  public void getPhoneNumber(Promise p) { p.resolve(getPhoneNumberSync()); }
-
   @ReactMethod(isBlockingSynchronousMethod = true)
   public WritableArray getSupportedAbisSync() {
     WritableArray array = new WritableNativeArray();

--- a/example/App.js
+++ b/example/App.js
@@ -155,7 +155,6 @@ export default class App extends Component {
     deviceJSON.androidId = DeviceInfo.getAndroidIdSync();
     deviceJSON.IpAddress = DeviceInfo.getIpAddressSync();
     deviceJSON.MacAddress = DeviceInfo.getMacAddressSync(); // needs android.permission.ACCESS_WIFI_STATE
-    deviceJSON.phoneNumber = DeviceInfo.getPhoneNumberSync(); // needs android.permission.READ_PHONE_STATE
     deviceJSON.ApiLevel = DeviceInfo.getApiLevelSync();
     deviceJSON.carrier = DeviceInfo.getCarrierSync();
     deviceJSON.totalMemory = DeviceInfo.getTotalMemorySync();
@@ -232,7 +231,6 @@ export default class App extends Component {
       deviceJSON.androidId = await DeviceInfo.getAndroidId();
       deviceJSON.IpAddress = await DeviceInfo.getIpAddress();
       deviceJSON.MacAddress = await DeviceInfo.getMacAddress(); // needs android.permission.ACCESS_WIFI_STATE
-      deviceJSON.phoneNumber = await DeviceInfo.getPhoneNumber(); // needs android.permission.READ_PHONE_STATE
       deviceJSON.ApiLevel = await DeviceInfo.getApiLevel();
       deviceJSON.carrier = await DeviceInfo.getCarrier();
       deviceJSON.totalMemory = await DeviceInfo.getTotalMemory();

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -64,7 +64,6 @@ const stringFnNames = [
   'getSecurityPatch',
   'getCodename',
   'getIncremental',
-  'getPhoneNumber',
   'getCarrier',
   'getInstallReferrer',
 ];

--- a/jest/react-native-device-info-mock.js
+++ b/jest/react-native-device-info-mock.js
@@ -69,8 +69,6 @@ const diMock = {
   getMacAddressSync: stringFnSync(),
   getMaxMemory: numberFnAsync(),
   getMaxMemorySync: numberFnSync(),
-  getPhoneNumber: stringFnAsync(),
-  getPhoneNumberSync: stringFnSync(),
   getPreviewSdkInt: numberFnAsync(),
   getPreviewSdkIntSync: numberFnSync(),
   getProduct: stringFnAsync(),

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -87,8 +87,6 @@ declare module.exports: {
   getMaxMemory: () => Promise<number>,
   getMaxMemorySync: () => number,
   getModel: () => string,
-  getPhoneNumber: () => Promise<string>,
-  getPhoneNumberSync: () => string,
   getPowerState: () => Promise<PowerState | {}>,
   getPowerStateSync: () => PowerState | {},
   getPreviewSdkInt: () => Promise<number>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,13 +475,6 @@ export const [getLastUpdateTime, getLastUpdateTimeSync] = getSupportedPlatformIn
   defaultValue: -1,
 });
 
-export const [getPhoneNumber, getPhoneNumberSync] = getSupportedPlatformInfoFunctions({
-  supportedPlatforms: ['android'],
-  getter: () => RNDeviceInfo.getPhoneNumber(),
-  syncGetter: () => RNDeviceInfo.getPhoneNumberSync(),
-  defaultValue: 'unknown',
-});
-
 export const [getCarrier, getCarrierSync] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios'],
   getter: () => RNDeviceInfo.getCarrier(),
@@ -968,8 +961,6 @@ const DeviceInfo: DeviceInfoModule = {
   getMaxMemory,
   getMaxMemorySync,
   getModel,
-  getPhoneNumber,
-  getPhoneNumberSync,
   getPowerState,
   getPowerStateSync,
   getPreviewSdkInt,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -95,8 +95,6 @@ interface ExposedNativeMethods {
   getMacAddressSync: () => string;
   getMaxMemory: () => Promise<number>;
   getMaxMemorySync: () => number;
-  getPhoneNumber: () => Promise<string>;
-  getPhoneNumberSync: () => string;
   getPreviewSdkInt: () => Promise<number>;
   getPreviewSdkIntSync: () => number;
   getProduct: () => Promise<string>;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #1612 

The getPhoneNumber() method has been removed. Because this method uses deprecated getLine1Number function. It is recommended to use alternative methods to get phone numbers from SIM cards.  You can use https://github.com/odemolliens/react-native-sim-cards-manager instead.

<!-- OR, if you're implementing a new feature: -->

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
