### PR TITLE
feat(android)!: targetSdk 34 requires receiver export specification during registration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 30)
+    compileSdkVersion safeExtGet('compileSdkVersion', 34)
     
     def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
     // Check AGP version for backward compatibility reasons

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -33,6 +33,7 @@ import android.hardware.Camera;
 import android.hardware.camera2.CameraManager;
 
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -135,7 +136,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     };
 
-    getReactApplicationContext().registerReceiver(receiver, filter);
+    ContextCompat.registerReceiver(getReactApplicationContext(), receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
     initializeHeadphoneConnectionReceivers();
   }
 
@@ -153,7 +154,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     };
 
-    getReactApplicationContext().registerReceiver(headphoneConnectionReceiver, filter);
+    ContextCompat.registerReceiver(getReactApplicationContext(), headphoneConnectionReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
 
     // 2. Filter for wired headset
     IntentFilter filterWired = new IntentFilter();
@@ -167,7 +168,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     };
 
-    getReactApplicationContext().registerReceiver(headphoneWiredConnectionReceiver, filterWired);
+    ContextCompat.registerReceiver(getReactApplicationContext(), headphoneWiredConnectionReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
 
     // 3. Filter for bluetooth headphones
     IntentFilter filterBluetooth = new IntentFilter();
@@ -181,7 +182,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     };
 
-    getReactApplicationContext().registerReceiver(headphoneBluetoothConnectionReceiver, filterBluetooth);
+    ContextCompat.registerReceiver(getReactApplicationContext(), headphoneBluetoothConnectionReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
   }
 
   @Override

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -33,7 +33,6 @@ import android.hardware.Camera;
 import android.hardware.camera2.CameraManager;
 
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -136,7 +135,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     };
 
-    ContextCompat.registerReceiver(getReactApplicationContext(), receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
+    registerReceiver(getReactApplicationContext(), receiver, filter);
     initializeHeadphoneConnectionReceivers();
   }
 
@@ -154,7 +153,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     };
 
-    ContextCompat.registerReceiver(getReactApplicationContext(), headphoneConnectionReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
+    registerReceiver(getReactApplicationContext(), headphoneConnectionReceiver, filter);
 
     // 2. Filter for wired headset
     IntentFilter filterWired = new IntentFilter();
@@ -168,7 +167,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     };
 
-    ContextCompat.registerReceiver(getReactApplicationContext(), headphoneWiredConnectionReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
+    registerReceiver(getReactApplicationContext(), headphoneWiredConnectionReceiver, filter);
 
     // 3. Filter for bluetooth headphones
     IntentFilter filterBluetooth = new IntentFilter();
@@ -182,7 +181,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     };
 
-    ContextCompat.registerReceiver(getReactApplicationContext(), headphoneBluetoothConnectionReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
+    registerReceiver(getReactApplicationContext(), headphoneBluetoothConnectionReceiver, filter);
   }
 
   @Override
@@ -1081,5 +1080,14 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getSupportedMediaTypeList(Promise promise) {
     promise.resolve(getSupportedMediaTypeListSync());
+  }
+
+  @SuppressLint("UnspecifiedRegisterReceiverFlag")
+  private void registerReceiver(Context context, BroadcastReceiver receiver, IntentFilter filter) {
+    if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
+      context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED);
+    } else {
+      context.registerReceiver(receiver, filter);
+    }
   }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
+        compileSdkVersion = 33
         targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
     }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Targeting Android 14 requires the specification of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED when registering a receiver. Docs: https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported

<!-- OR, if you're implementing a new feature: -->

using CompatConext allow us to avoid the android version check as it handles it internally

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [n/a (Only android) ] I have tested this on a device/simulator for each compatible OS
* [ n/a] I added the documentation in `README.md`
* [ n/a] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ n/a] I added a sample use of the API (`example/App.js`)
