### PR TITLE
fix react-native 0.74 Use invalidate method instead onCatalystInstanceDestroy

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -155,7 +155,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     getReactApplicationContext().unregisterReceiver(receiver);
     getReactApplicationContext().unregisterReceiver(headphoneConnectionReceiver);
   }


### PR DESCRIPTION
fix react-native 0.74 Use invalidate method instead onCatalystInstanceDestroy
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes 0

<!-- OR, if you're implementing a new feature: -->

Added `yourNewMethodName()` that allows ...

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
