### PR TITLE
fix(ios): Make unique id, unique per device and not per ios account(k…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,7 +1028,7 @@ DeviceInfo.getUniqueId().then((uniqueId) => {
 
 #### Notes
 
-> - iOS: This is [`IDFV`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) or a random string if IDFV is unavaliable. Once UID is generated it is stored in iOS Keychain and NSUserDefaults. So it would stay the same even if you delete the app or reset IDFV. You can _carefully_ consider it a persistent, cross-install unique ID. It can be changed only in case someone manually override values in Keychain/NSUserDefaults or if Apple would change Keychain and NSUserDefaults implementations.
+> - iOS: This is [`IDFV`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) or a random string if IDFV is unavaliable. Once UID is generated it is stored in iOS Keychain and NSUserDefaults. So it would stay the same even if you delete the app or reset IDFV. You can _carefully_ consider it a persistent unique ID. It can be changed only in case someone manually override values in Keychain/NSUserDefaults or if Apple would change Keychain and NSUserDefaults implementations.
 >   Beware: The IDFV is calculated using your bundle identifier and thus will be different in app extensions.
 > - android: Prior to Oreo, this id ([ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID)) will always be the same once you set up your phone.
 > - android: [Google Play policy](https://support.google.com/googleplay/android-developer/answer/10144311), see "persistent device identifiers". [Huawei - AppGallery Review Guidelines](https://developer.huawei.com/consumer/en/doc/30202) see "permanent device identifier" and "obtaining user consent".

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -274,7 +274,7 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNDeviceInfo (10.13.2):
+  - RNDeviceInfo (11.1.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -412,7 +412,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNDeviceInfo: 42aadf1282ffa0a88dc38a504a7be145eb010dfa
+  RNDeviceInfo: b899ce37a403a4dea52b7cb85e16e49c04a5b88e
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
 
 PODFILE CHECKSUM: bdf45547a4661149d5f0f9e028297666a4cdab29

--- a/ios/RNDeviceInfo/DeviceUID.m
+++ b/ios/RNDeviceInfo/DeviceUID.m
@@ -91,7 +91,7 @@ NSString * const UIDKey = @"deviceUID";
 + (NSMutableDictionary *)keychainItemForKey:(NSString *)key service:(NSString *)service {
     NSMutableDictionary *keychainItem = [[NSMutableDictionary alloc] init];
     keychainItem[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
-    keychainItem[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
+    keychainItem[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
     keychainItem[(__bridge id)kSecAttrAccount] = key;
     keychainItem[(__bridge id)kSecAttrService] = service;
     return keychainItem;


### PR DESCRIPTION
…eychain)


## Description

Fixes #1526

The unique id is persisted in the keychain using kSecAttrAccessibleAfterFirstUnlock.
This causes unexpected behaviors sometimes when using the same ios account in different devices.
The keychain syncs these variables and the device id is no longer unique.
To mitigate this, the breaking change is required to store the unique id per device only using the config variable
kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly instead.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist
* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
