### PR TITLE
feat: add getStartupTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The example app in this repository shows an example usage of every single API, c
 | [getReadableVersion()](#getreadableversion)                         | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
 | [getSerialNumber()](#getserialnumber)                               | `Promise<string>`   |  ❌  |   ✅    |   ✅     | ❌   |   ❌     |
 | [getSecurityPatch()](#getsecuritypatch)                             | `Promise<string>`   |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
+| [getStartupTime()](#getstartuptime)                                 | `Promise<number>`   |  ✅  |   ✅    |   ❌     | ❌   |   ✅     |
 | [getSystemAvailableFeatures()](#getSystemAvailableFeatures)         | `Promise<string[]>` |  ❌  |   ✅    |   ❌     | ❌   |   ❌     |
 | [getSystemName()](#getsystemname)                                   | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
 | [getSystemVersion()](#getsystemversion)                             | `string`            |  ✅  |   ✅    |   ✅     | ❌   |   ✅     |
@@ -895,6 +896,21 @@ let systemName = DeviceInfo.getSystemName();
 // iOS: "iOS" on newer iOS devices "iPhone OS" on older devices (including older iPad models), "iPadOS" for iPads using iPadOS 15.0 or higher.
 // Android: "Android"
 // Windows: ?
+```
+
+---
+
+### getStartupTime()
+
+Gets the time at which the current app process was started, in milliseconds.
+
+#### Examples
+
+```js
+DeviceInfo.getStartupTime().then((startupTime) => {
+  // Android: 1517681764528
+  // iOS: 1517681764528
+});
 ```
 
 ---

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -24,6 +24,7 @@ import android.os.StatFs;
 import android.os.BatteryManager;
 import android.os.Debug;
 import android.os.Process;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodInfo;
@@ -754,6 +755,22 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
   @ReactMethod
   public void getLastUpdateTime(Promise p) { p.resolve(getLastUpdateTimeSync()); }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public double getStartupTimeSync() {
+    // Get time in milliseconds since unix epoch
+    long currentTime = System.currentTimeMillis();
+    // Get the time when the process started in milliseconds since system boot
+    long processStartTime = Process.getStartUptimeMillis();
+    // Get the milliseconds since system boot time
+    long currentUptime = SystemClock.uptimeMillis();
+    // Calculate the process startup time in milliseconds since unix epoch
+    long startupTime = currentTime - currentUptime + processStartTime;
+    return BigInteger.valueOf(startupTime).doubleValue();
+  }
+
+  @ReactMethod
+  public void getStartupTime(Promise p) { p.resolve(getStartupTimeSync()); }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   public String getDeviceNameSync() {

--- a/example/App.js
+++ b/example/App.js
@@ -151,6 +151,7 @@ export default class App extends Component {
     deviceJSON.hasDynamicIsland = DeviceInfo.hasDynamicIsland();
     deviceJSON.firstInstallTime = DeviceInfo.getFirstInstallTimeSync();
     deviceJSON.lastUpdateTime = DeviceInfo.getLastUpdateTimeSync();
+    deviceJSON.startupTime = DeviceInfo.getStartupTimeSync();
     deviceJSON.serialNumber = DeviceInfo.getSerialNumberSync();
     deviceJSON.androidId = DeviceInfo.getAndroidIdSync();
     deviceJSON.IpAddress = DeviceInfo.getIpAddressSync();
@@ -227,6 +228,7 @@ export default class App extends Component {
       deviceJSON.hasDynamicIsland = await DeviceInfo.hasDynamicIsland();
       deviceJSON.firstInstallTime = await DeviceInfo.getFirstInstallTime();
       deviceJSON.lastUpdateTime = await DeviceInfo.getLastUpdateTime();
+      deviceJSON.startupTime = await DeviceInfo.getStartupTime();
       deviceJSON.serialNumber = await DeviceInfo.getSerialNumber();
       deviceJSON.androidId = await DeviceInfo.getAndroidId();
       deviceJSON.IpAddress = await DeviceInfo.getIpAddress();

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -971,6 +971,8 @@ RCT_EXPORT_METHOD(getStartupTime:(RCTPromiseResolveBlock)resolve rejecter:(RCTPr
     resolve(@(self.getStartupTime));
 }
  
+// Reads the process startup time and returns it in milliseconds since 1970
+// Reading the process startup time from the system is more accurate than comparing a date which is initiallized at launch with the current time
 - (long long) getStartupTime {
     size_t len = 4;
     int mib[len];

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -963,6 +963,29 @@ RCT_EXPORT_METHOD(getFirstInstallTime:(RCTPromiseResolveBlock)resolve rejecter:(
     return [@(floor([installDate timeIntervalSince1970] * 1000)) longLongValue];
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getStartupTimeSync) {
+    return @(self.getStartupTime);
+}
+
+RCT_EXPORT_METHOD(getStartupTime:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve(@(self.getStartupTime));
+}
+ 
+- (long long) getStartupTime {
+    size_t len = 4;
+    int mib[len];
+    struct kinfo_proc kp;
+
+    sysctlnametomib("kern.proc.pid", mib, &len);
+    mib[3] = getpid();
+    len = sizeof(kp);
+    sysctl(mib, 4, &kp, &len, NULL, 0);
+
+    struct timeval startTime = kp.kp_proc.p_un.__p_starttime;
+    double startTimeMilliSeconds = startTime.tv_sec * 1e3 + startTime.tv_usec / 1e3;
+    return [@(floor(startTimeMilliSeconds)) longLongValue];
+}
+
 #pragma mark - dealloc -
 
 - (void)dealloc

--- a/jest/react-native-device-info-mock.js
+++ b/jest/react-native-device-info-mock.js
@@ -77,6 +77,8 @@ const diMock = {
   getSecurityPatchSync: stringFnSync(),
   getSerialNumber: stringFnAsync(),
   getSerialNumberSync: stringFnSync(),
+  getStartupTime: stringFnAsync(),
+  getStartupTimeSync: stringFnSync(),
   getSystemAvailableFeatures: arrayFnAsync(),
   getSystemAvailableFeaturesSync: arrayFnSync(),
   getTags: stringFnAsync(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,6 +475,14 @@ export const [getLastUpdateTime, getLastUpdateTimeSync] = getSupportedPlatformIn
   defaultValue: -1,
 });
 
+export const [getStartupTime, getStartupTimeSync] = getSupportedPlatformInfoFunctions({
+  memoKey: 'startupTime',
+  supportedPlatforms: ['android', 'ios'],
+  getter: () => RNDeviceInfo.getStartupTime(),
+  syncGetter: () => RNDeviceInfo.getStartupTimeSync(),
+  defaultValue: -1,
+});
+
 export const [getCarrier, getCarrierSync] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios'],
   getter: () => RNDeviceInfo.getCarrier(),
@@ -972,6 +980,8 @@ const DeviceInfo: DeviceInfoModule = {
   getSecurityPatchSync,
   getSerialNumber,
   getSerialNumberSync,
+  getStartupTime,
+  getStartupTimeSync,
   getSystemAvailableFeatures,
   getSystemAvailableFeaturesSync,
   getSystemName,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -103,6 +103,8 @@ interface ExposedNativeMethods {
   getSecurityPatchSync: () => string;
   getSerialNumber: () => Promise<string>;
   getSerialNumberSync: () => string;
+  getStartupTime: () => Promise<number>;
+  getStartupTimeSync: () => number;
   getSystemAvailableFeatures: () => Promise<string[]>;
   getSystemAvailableFeaturesSync: () => string[];
   getTags: () => Promise<string>;


### PR DESCRIPTION
## Description

Added `getStartupTime()` that allows getting the startup time of the app in milliseconds since the unix epoch. 

This can for example be used to measure the time since app launch via `new Date().getTime() - getStartupTimeSync()`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [X] I added a sample use of the API (`example/App.js`)
