### PR TITLE
fix(ios): isDisplayZoomed on iPhone 12/13 mini

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -179,7 +179,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 
 - (BOOL) isDisplayZoomed {
     #if !TARGET_OS_VISION
-        return [UIScreen mainScreen].scale != [UIScreen mainScreen].nativeScale;
+        return [UIScreen mainScreen].scale < [UIScreen mainScreen].nativeScale;
     #else
         return NO;
     #endif


### PR DESCRIPTION
## Description

Fixes #1581.

On iPhone 12 mini and iPhone 13 mini, `isDisplayZoomed()` always returns true, independent of whether `Display & Brightness` -> `Display Zoom` is enabled.

We fix this issue by changing the comparison operator (see [here](https://stackoverflow.com/a/65844985)).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
