### PR TITLE
feat(ios): add iPhone 16 device names / add missing iPad device names

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -279,6 +279,10 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone15,5": @"iPhone 15 Plus",
         @"iPhone16,1": @"iPhone 15 Pro",
         @"iPhone16,2": @"iPhone 15 Pro Max",
+        @"iPhone17,1": @"iPhone 16 Pro",
+        @"iPhone17,2": @"iPhone 16 Pro Max",
+        @"iPhone17,3": @"iPhone 16",
+        @"iPhone17,4": @"iPhone 16 Plus",
         @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
         @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
         @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -205,36 +205,15 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 
 - (NSDictionary *) getDeviceNamesByCode {
     return @{
-        @"iPod1,1": @"iPod Touch", // (Original)
-        @"iPod2,1": @"iPod Touch", // (Second Generation)
-        @"iPod3,1": @"iPod Touch", // (Third Generation)
-        @"iPod4,1": @"iPod Touch", // (Fourth Generation)
-        @"iPod5,1": @"iPod Touch", // (Fifth Generation)
-        @"iPod7,1": @"iPod Touch", // (Sixth Generation)
-        @"iPod9,1": @"iPod Touch", // (Seventh Generation)
         @"iPhone1,1": @"iPhone", // (Original)
         @"iPhone1,2": @"iPhone 3G", // (3G)
         @"iPhone2,1": @"iPhone 3GS", // (3GS)
-        @"iPad1,1": @"iPad", // (Original)
-        @"iPad2,1": @"iPad 2", //
-        @"iPad2,2": @"iPad 2", //
-        @"iPad2,3": @"iPad 2", //
-        @"iPad2,4": @"iPad 2", //
-        @"iPad3,1": @"iPad", // (3rd Generation)
-        @"iPad3,2": @"iPad", // (3rd Generation)
-        @"iPad3,3": @"iPad", // (3rd Generation)
         @"iPhone3,1": @"iPhone 4", // (GSM)
         @"iPhone3,2": @"iPhone 4", // iPhone 4
         @"iPhone3,3": @"iPhone 4", // (CDMA/Verizon/Sprint)
         @"iPhone4,1": @"iPhone 4S", //
         @"iPhone5,1": @"iPhone 5", // (model A1428, AT&T/Canada)
         @"iPhone5,2": @"iPhone 5", // (model A1429, everything else)
-        @"iPad3,4": @"iPad", // (4th Generation)
-        @"iPad3,5": @"iPad", // (4th Generation)
-        @"iPad3,6": @"iPad", // (4th Generation)
-        @"iPad2,5": @"iPad Mini", // (Original)
-        @"iPad2,6": @"iPad Mini", // (Original)
-        @"iPad2,7": @"iPad Mini", // (Original)
         @"iPhone5,3": @"iPhone 5c", // (model A1456, A1532 | GSM)
         @"iPhone5,4": @"iPhone 5c", // (model A1507, A1516, A1526 (China), A1529 | Global)
         @"iPhone6,1": @"iPhone 5s", // (model A1433, A1533 | GSM)
@@ -245,15 +224,15 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone8,2": @"iPhone 6s Plus", //
         @"iPhone8,4": @"iPhone SE", //
         @"iPhone9,1": @"iPhone 7", // (model A1660 | CDMA)
-        @"iPhone9,3": @"iPhone 7", // (model A1778 | Global)
         @"iPhone9,2": @"iPhone 7 Plus", // (model A1661 | CDMA)
+        @"iPhone9,3": @"iPhone 7", // (model A1778 | Global)
         @"iPhone9,4": @"iPhone 7 Plus", // (model A1784 | Global)
-        @"iPhone10,3": @"iPhone X", // (model A1865, A1902)
-        @"iPhone10,6": @"iPhone X", // (model A1901)
         @"iPhone10,1": @"iPhone 8", // (model A1863, A1906, A1907)
-        @"iPhone10,4": @"iPhone 8", // (model A1905)
         @"iPhone10,2": @"iPhone 8 Plus", // (model A1864, A1898, A1899)
+        @"iPhone10,3": @"iPhone X", // (model A1865, A1902)
+        @"iPhone10,4": @"iPhone 8", // (model A1905)
         @"iPhone10,5": @"iPhone 8 Plus", // (model A1897)
+        @"iPhone10,6": @"iPhone X", // (model A1901)
         @"iPhone11,2": @"iPhone XS", // (model A2097, A2098)
         @"iPhone11,4": @"iPhone XS Max", // (model A1921, A2103)
         @"iPhone11,6": @"iPhone XS Max", // (model A2104)
@@ -266,10 +245,10 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone13,2": @"iPhone 12",
         @"iPhone13,3": @"iPhone 12 Pro",
         @"iPhone13,4": @"iPhone 12 Pro Max",
-        @"iPhone14,4": @"iPhone 13 mini",
-        @"iPhone14,5": @"iPhone 13",
         @"iPhone14,2": @"iPhone 13 Pro",
         @"iPhone14,3": @"iPhone 13 Pro Max",
+        @"iPhone14,4": @"iPhone 13 mini",
+        @"iPhone14,5": @"iPhone 13",
         @"iPhone14,6": @"iPhone SE", // (3nd Generation iPhone SE),
         @"iPhone14,7": @"iPhone 14",
         @"iPhone14,8": @"iPhone 14 Plus",
@@ -283,52 +262,112 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone17,2": @"iPhone 16 Pro Max",
         @"iPhone17,3": @"iPhone 16",
         @"iPhone17,4": @"iPhone 16 Plus",
-        @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
-        @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
-        @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)
-        @"iPad4,4": @"iPad Mini 2", // (2nd Generation iPad Mini - Wifi)
-        @"iPad4,5": @"iPad Mini 2", // (2nd Generation iPad Mini - Cellular)
-        @"iPad4,6": @"iPad Mini 2", // (2nd Generation iPad Mini)
-        @"iPad4,7": @"iPad Mini 3", // (3rd Generation iPad Mini)
-        @"iPad4,8": @"iPad Mini 3", // (3rd Generation iPad Mini)
-        @"iPad4,9": @"iPad Mini 3", // (3rd Generation iPad Mini)
-        @"iPad5,1": @"iPad Mini 4", // (4th Generation iPad Mini)
-        @"iPad5,2": @"iPad Mini 4", // (4th Generation iPad Mini)
-        @"iPad5,3": @"iPad Air 2", // 6th Generation iPad (iPad Air 2)
-        @"iPad5,4": @"iPad Air 2", // 6th Generation iPad (iPad Air 2)
-        @"iPad6,3": @"iPad Pro 9.7-inch", // iPad Pro 9.7-inch
-        @"iPad6,4": @"iPad Pro 9.7-inch", // iPad Pro 9.7-inch
-        @"iPad6,7": @"iPad Pro 12.9-inch", // iPad Pro 12.9-inch
-        @"iPad6,8": @"iPad Pro 12.9-inch", // iPad Pro 12.9-inch
-        @"iPad6,11": @"iPad (5th generation)", // Apple iPad 9.7 inch (5th generation) - WiFi
-        @"iPad6,12": @"iPad (5th generation)", // Apple iPad 9.7 inch (5th generation) - WiFi + cellular
-        @"iPad7,1": @"iPad Pro 12.9-inch", // 2nd Generation iPad Pro 12.5-inch - Wifi
-        @"iPad7,2": @"iPad Pro 12.9-inch", // 2nd Generation iPad Pro 12.5-inch - Cellular
-        @"iPad7,3": @"iPad Pro 10.5-inch", // iPad Pro 10.5-inch - Wifi
-        @"iPad7,4": @"iPad Pro 10.5-inch", // iPad Pro 10.5-inch - Cellular
-        @"iPad7,5": @"iPad (6th generation)", // iPad (6th generation) - Wifi
-        @"iPad7,6": @"iPad (6th generation)", // iPad (6th generation) - Cellular
-        @"iPad7,11": @"iPad (7th generation)", // iPad 10.2 inch (7th generation) - Wifi
-        @"iPad7,12": @"iPad (7th generation)", // iPad 10.2 inch (7th generation) - Wifi + cellular
-        @"iPad8,1": @"iPad Pro 11-inch (3rd generation)", // iPad Pro 11 inch (3rd generation) - Wifi
-        @"iPad8,2": @"iPad Pro 11-inch (3rd generation)", // iPad Pro 11 inch (3rd generation) - 1TB - Wifi
-        @"iPad8,3": @"iPad Pro 11-inch (3rd generation)", // iPad Pro 11 inch (3rd generation) - Wifi + cellular
-        @"iPad8,4": @"iPad Pro 11-inch (3rd generation)", // iPad Pro 11 inch (3rd generation) - 1TB - Wifi + cellular
-        @"iPad8,5": @"iPad Pro 12.9-inch (3rd generation)", // iPad Pro 12.9 inch (3rd generation) - Wifi
-        @"iPad8,6": @"iPad Pro 12.9-inch (3rd generation)", // iPad Pro 12.9 inch (3rd generation) - 1TB - Wifi
-        @"iPad8,7": @"iPad Pro 12.9-inch (3rd generation)", // iPad Pro 12.9 inch (3rd generation) - Wifi + cellular
-        @"iPad8,8": @"iPad Pro 12.9-inch (3rd generation)", // iPad Pro 12.9 inch (3rd generation) - 1TB - Wifi + cellular
-        @"iPad11,1": @"iPad Mini 5", // (5th Generation iPad Mini)
-        @"iPad11,2": @"iPad Mini 5", // (5th Generation iPad Mini)
-        @"iPad11,3": @"iPad Air (3rd generation)",
+
+        @"iPod1,1": @"iPod Touch", // (Original)
+        @"iPod2,1": @"iPod Touch", // (Second Generation)
+        @"iPod3,1": @"iPod Touch", // (Third Generation)
+        @"iPod4,1": @"iPod Touch", // (Fourth Generation)
+        @"iPod5,1": @"iPod Touch", // (Fifth Generation)
+        @"iPod7,1": @"iPod Touch", // (Sixth Generation)
+        @"iPod9,1": @"iPod Touch", // (Seventh Generation)
+
+        @"iPad1,1": @"iPad",
+        @"iPad1,2": @"iPad 3G",
+        @"iPad2,1": @"iPad 2",
+        @"iPad2,2": @"iPad 2",
+        @"iPad2,3": @"iPad 2",
+        @"iPad2,4": @"iPad 2",
+        @"iPad3,1": @"iPad",
+        @"iPad3,2": @"iPad",
+        @"iPad3,3": @"iPad",
+        @"iPad2,5": @"iPad mini",
+        @"iPad2,6": @"iPad mini",
+        @"iPad2,7": @"iPad mini",
+        @"iPad3,4": @"iPad",
+        @"iPad3,5": @"iPad",
+        @"iPad3,6": @"iPad",
+        @"iPad4,1": @"iPad Air",
+        @"iPad4,2": @"iPad Air",
+        @"iPad4,3": @"iPad Air",
+        @"iPad4,4": @"iPad Mini 2",
+        @"iPad4,5": @"iPad Mini 2",
+        @"iPad4,6": @"iPad Mini 2",
+        @"iPad4,7": @"iPad Mini 3",
+        @"iPad4,8": @"iPad Mini 3",
+        @"iPad4,9": @"iPad Mini 3",
+        @"iPad5,1": @"iPad Mini 4",
+        @"iPad5,2": @"iPad Mini 4",
+        @"iPad5,3": @"iPad Air 2",
+        @"iPad5,4": @"iPad Air 2",
+        @"iPad6,3": @"iPad Pro 9.7-inch",
+        @"iPad6,4": @"iPad Pro 9.7-inch",
+        @"iPad6,7": @"iPad Pro 12.9-inch",
+        @"iPad6,8":@"iPad Pro 12.9-inch",
+        @"iPad6,11": @"iPad (5th generation)",
+        @"iPad6,12": @"iPad (5th generation)",
+        @"iPad7,1": @"iPad Pro 12.9-inch",
+        @"iPad7,2": @"iPad Pro 12.9-inch",
+        @"iPad7,3": @"iPad Pro 10.5-inch",
+        @"iPad7,4": @"iPad Pro 10.5-inch",
+        @"iPad7,5": @"iPad (6th generation)",
+        @"iPad7,6": @"iPad (6th generation)",
+        @"iPad7,11": @"iPad (7th generation)",
+        @"iPad7,12": @"iPad (7th generation)",
+        @"iPad8,1": @"iPad Pro 11-inch (3rd generation)",
+        @"iPad8,2": @"iPad Pro 11-inch (3rd generation)",
+        @"iPad8,3": @"iPad Pro 11-inch (3rd generation)",
+        @"iPad8,4": @"iPad Pro 11-inch (3rd generation)",
+        @"iPad8,5": @"iPad Pro 12.9-inch (3rd generation)",
+        @"iPad8,6": @"iPad Pro 12.9-inch (3rd generation)",
+        @"iPad8,7": @"iPad Pro 12.9-inch (3rd generation)",
+        @"iPad8,8": @"iPad Pro 12.9-inch (3rd generation)",
+        @"iPad8,9": @"iPad Pro 11-inch (4th generation)",
+        @"iPad8,10": @"iPad Pro 11-inch (4th generation)",
+        @"iPad8,11": @"iPad Pro 12.9-inch (4th generation)",
+        @"iPad8,12": @"iPad Pro 12.9-inch (4th generation)",
+        @"iPad11,1": @"iPad Mini 5",
+        @"iPad11,2": @"iPad Mini 5",
+        @"iPad11,3": @"iPad Air 3rd Gen (WiFi)",
         @"iPad11,4": @"iPad Air (3rd generation)",
+        @"iPad11,6": @"iPad Air (3rd generation)",
+        @"iPad11,7": @"iPad (8th generation)",
+        @"iPad12,1": @"iPad (9th generation)",
+        @"iPad12,2": @"iPad (9th generation)",
+        @"iPad14,1": @"iPad Mini (6th generation)",
+        @"iPad14,2": @"iPad Mini (6th generation)",
         @"iPad13,1": @"iPad Air (4th generation)",
         @"iPad13,2": @"iPad Air (4th generation)",
+        @"iPad13,4": @"iPad Pro 11-inch (5th generation)",
+        @"iPad13,5": @"iPad Pro 11-inch (5th generation)",
+        @"iPad13,6": @"iPad Pro 11-inch (5th generation)",
+        @"iPad13,7": @"iPad Pro 11-inch (5th generation)",
+        @"iPad13,8": @"iPad Pro 12.9-inch (5th generation)",
+        @"iPad13,9": @"iPad Pro 11-inch (5th generation)",
+        @"iPad13,10": @"iPad Pro 11-inch (5th generation)",
+        @"iPad13,11": @"iPad Pro 11-inch (5th generation)",
+        @"iPad13,16": @"iPad Air (5th generation)",
+        @"iPad13,17": @"iPad Air (5th generation)",
+        @"iPad13,18": @"iPad (10th generation)",
+        @"iPad13,19": @"iPad (10th generation)",
+        @"iPad14,3": @"iPad Pro 11-inch (4th generation)",
+        @"iPad14,4": @"iPad Pro 11-inch (4th generation)",
+        @"iPad14,5": @"iPad Pro 12.9-inch (6th generation)",
+        @"iPad14,6": @"iPad Pro 12.9-inch (6th generation)",
+        @"iPad14,8": @"iPad Air (6th generation)",
+        @"iPad14,9": @"iPad Air (6th generation)",
+        @"iPad14,10": @"iPad Air (7th generation)",
+        @"iPad14,11": @"iPad Air (7th generation)",
+        @"iPad16,3": @"iPad Pro 11-inch (5th generation)",
+        @"iPad16,4": @"iPad Pro 11-inch (5th generation)",
+        @"iPad16,5": @"iPad Pro 12.9-inch (7th generation)",
+        @"iPad16,6": @"iPad Pro 12.9-inch (7th generation)",
+
         @"AppleTV2,1": @"Apple TV", // Apple TV (2nd Generation)
         @"AppleTV3,1": @"Apple TV", // Apple TV (3rd Generation)
         @"AppleTV3,2": @"Apple TV", // Apple TV (3rd Generation - Rev A)
         @"AppleTV5,3": @"Apple TV", // Apple TV (4th Generation)
         @"AppleTV6,2": @"Apple TV 4K", // Apple TV 4K
+
         @"RealityDevice14,1": @"Apple Vision Pro" // Apple Vision Pro
     };
 }

--- a/src/internal/devicesWithDynamicIsland.ts
+++ b/src/internal/devicesWithDynamicIsland.ts
@@ -3,6 +3,22 @@ import { NotchDevice } from './privateTypes';
 const devicesWithDynamicIsland: NotchDevice[] = [
   {
     brand: 'Apple',
+    model: 'iPhone 16',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 16 Plus',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 16 Pro',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 16 Pro Max',
+  },
+  {
+    brand: 'Apple',
     model: 'iPhone 15',
   },
   {

--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -3,6 +3,22 @@ import { NotchDevice } from './privateTypes';
 const devicesWithNotch: NotchDevice[] = [
   {
     brand: 'Apple',
+    model: 'iPhone 16',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 16 Plus',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 16 Pro',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 16 Pro Max',
+  },
+  {
+    brand: 'Apple',
     model: 'iPhone 15',
   },
   {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Added iPhone 16 support for notch and dynamic island. 

Devices codes picked from: https://gist.github.com/adamawolf/3048717

Fixes #1541
Supercedes #1619

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
