### PR TITLE
feat(ios): implement all free disk storage types for ios 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,12 +527,23 @@ DeviceInfo.getFontScale().then((fontScale) => {
 
 Method that gets available storage size, in bytes, taking into account both root and data file systems calculation.
 
+On **iOS**, this method accepts the following optional arguments:
+- `'total'`: Uses `volumeAvailableCapacityKey`
+- `'important'`: Uses `volumeAvailableCapacityForImportantUsageKey`
+- `'opportunistic'`: Uses `volumeAvailableCapacityForOpportunisticUsageKey`
+
+For more details, refer to [Apple Documentation on Checking Volume Storage Capacity](https://developer.apple.com/documentation/foundation/urlresourcekey/checking_volume_storage_capacity).
+
 #### Examples
 
 ```js
 DeviceInfo.getFreeDiskStorage().then((freeDiskStorage) => {
   // Android: 17179869184
   // iOS: 17179869184
+});
+
+DeviceInfo.getFreeDiskStorage('important').then((freeDiskStorage) => {
+  // iOS: 18198219342 (important storage)
 });
 ```
 

--- a/example/App.js
+++ b/example/App.js
@@ -161,7 +161,12 @@ export default class App extends Component {
     deviceJSON.maxMemory = DeviceInfo.getMaxMemorySync();
     deviceJSON.totalDiskCapacity = DeviceInfo.getTotalDiskCapacitySync();
     deviceJSON.totalDiskCapacityOld = DeviceInfo.getTotalDiskCapacityOldSync();
-    deviceJSON.freeDiskStorage = DeviceInfo.getFreeDiskStorageSync();
+    deviceJSON.freeDiskStorage = {
+      default: DeviceInfo.getFreeDiskStorageSync(),
+      total: DeviceInfo.getFreeDiskStorageSync('total'),
+      important: DeviceInfo.getFreeDiskStorageSync('important'),
+      opportunistic: DeviceInfo.getFreeDiskStorageSync('opportunistic'),
+    };
     deviceJSON.freeDiskStorageOld = DeviceInfo.getFreeDiskStorageOldSync();
     deviceJSON.batteryLevel = DeviceInfo.getBatteryLevelSync();
     deviceJSON.isLandscape = DeviceInfo.isLandscapeSync();
@@ -237,7 +242,12 @@ export default class App extends Component {
       deviceJSON.maxMemory = await DeviceInfo.getMaxMemory();
       deviceJSON.totalDiskCapacity = await DeviceInfo.getTotalDiskCapacity();
       deviceJSON.totalDiskCapacityOld = await DeviceInfo.getTotalDiskCapacityOld();
-      deviceJSON.freeDiskStorage = await DeviceInfo.getFreeDiskStorage();
+      deviceJSON.freeDiskStorage = {
+        default: await DeviceInfo.getFreeDiskStorage(),
+        total: await DeviceInfo.getFreeDiskStorage('total'),
+        important: await DeviceInfo.getFreeDiskStorage('important'),
+        opportunistic: await DeviceInfo.getFreeDiskStorage('opportunistic'),
+      };
       deviceJSON.freeDiskStorageOld = await DeviceInfo.getFreeDiskStorageOld();
       deviceJSON.batteryLevel = await DeviceInfo.getBatteryLevel();
       deviceJSON.isLandscape = await DeviceInfo.isLandscape();

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -599,7 +599,6 @@ RCT_EXPORT_METHOD(getTotalDiskCapacity:(RCTPromiseResolveBlock)resolve rejecter:
 }
 
 - (double)getFreeDiskStorage {
-    uint64_t freeSpace = 0;
     NSError *error = nil;
 
     // iOS 11 and above: Use NSURLVolumeAvailableCapacityForImportantUsageKey
@@ -613,16 +612,12 @@ RCT_EXPORT_METHOD(getTotalDiskCapacity:(RCTPromiseResolveBlock)resolve rejecter:
             return 0;
         }
 
-        if (storageValues) {
-            NSNumber *availableCapacityForImportantUsage = storageValues[NSURLVolumeAvailableCapacityForImportantUsageKey];
-            if (availableCapacityForImportantUsage) {
-                freeSpace = [availableCapacityForImportantUsage unsignedLongLongValue];
-            }
+        NSNumber *availableCapacityForImportantUsage = [storageValues objectForKey:NSURLVolumeAvailableCapacityForImportantUsageKey];
+        if (availableCapacityForImportantUsage) {
+            return (double)[availableCapacityForImportantUsage unsignedLongLongValue];
         }
-    }
-
-    // Fallback for older iOS versions: Use NSFileSystemFreeSize
-    if (freeSpace == 0 && !error) {
+    } else {
+        // Fallback for older iOS versions: Use NSFileSystemFreeSize
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
         NSDictionary *dictionary = [[NSFileManager defaultManager] attributesOfFileSystemForPath:[paths lastObject] error:&error];
 
@@ -631,13 +626,13 @@ RCT_EXPORT_METHOD(getTotalDiskCapacity:(RCTPromiseResolveBlock)resolve rejecter:
             return 0;
         }
 
-        if (dictionary) {
-            NSNumber *freeFileSystemSizeInBytes = [dictionary objectForKey:NSFileSystemFreeSize];
-            freeSpace = [freeFileSystemSizeInBytes unsignedLongLongValue];
+        NSNumber *freeFileSystemSizeInBytes = [dictionary objectForKey:NSFileSystemFreeSize];
+        if (freeFileSystemSizeInBytes) {
+            return (double)[freeFileSystemSizeInBytes unsignedLongLongValue];
         }
     }
 
-    return (double)freeSpace;
+    return 0;
 }
 
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "example:install:pods": "cd example/ios && pod install",
     "example:android": "cd example && yarn android",
     "example:android:build": "cd example/android && ./gradlew assembleDebug",
-    "example:ios": "cd example && yarn ios --simulator 'iPhone 14'",
+    "example:ios": "cd example && yarn ios --simulator 'iPhone 16'",
     "example:ios:build": "cd example/ios && xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace example.xcworkspace -configuration Debug -scheme example -sdk iphonesimulator -arch x86_64 ONLY_ACTIVE_ARCH=YES | xcpretty",
     "example:windows": "cd example && yarn windows",
     "example:packager": "cd example && yarn start",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Dimensions, NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import { useOnEvent, useOnMount } from './internal/asyncHookWrappers';
-import devicesWithDynamicIsland from "./internal/devicesWithDynamicIsland";
+import devicesWithDynamicIsland from './internal/devicesWithDynamicIsland';
 import devicesWithNotch from './internal/devicesWithNotch';
 import RNDeviceInfo from './internal/nativeInterface';
 import {
@@ -697,23 +697,25 @@ export const [isHeadphonesConnected, isHeadphonesConnectedSync] = getSupportedPl
   }
 );
 
-export const [isWiredHeadphonesConnected, isWiredHeadphonesConnectedSync] = getSupportedPlatformInfoFunctions(
-  {
-    supportedPlatforms: ['android', 'ios'],
-    getter: () => RNDeviceInfo.isWiredHeadphonesConnected(),
-    syncGetter: () => RNDeviceInfo.isWiredHeadphonesConnectedSync(),
-    defaultValue: false,
-  }
-);
+export const [
+  isWiredHeadphonesConnected,
+  isWiredHeadphonesConnectedSync,
+] = getSupportedPlatformInfoFunctions({
+  supportedPlatforms: ['android', 'ios'],
+  getter: () => RNDeviceInfo.isWiredHeadphonesConnected(),
+  syncGetter: () => RNDeviceInfo.isWiredHeadphonesConnectedSync(),
+  defaultValue: false,
+});
 
-export const [isBluetoothHeadphonesConnected, isBluetoothHeadphonesConnectedSync] = getSupportedPlatformInfoFunctions(
-  {
-    supportedPlatforms: ['android', 'ios'],
-    getter: () => RNDeviceInfo.isBluetoothHeadphonesConnected(),
-    syncGetter: () => RNDeviceInfo.isBluetoothHeadphonesConnectedSync(),
-    defaultValue: false,
-  }
-);
+export const [
+  isBluetoothHeadphonesConnected,
+  isBluetoothHeadphonesConnectedSync,
+] = getSupportedPlatformInfoFunctions({
+  supportedPlatforms: ['android', 'ios'],
+  getter: () => RNDeviceInfo.isBluetoothHeadphonesConnected(),
+  syncGetter: () => RNDeviceInfo.isBluetoothHeadphonesConnectedSync(),
+  defaultValue: false,
+});
 
 export const [isMouseConnected, isMouseConnectedSync] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['windows'],
@@ -729,15 +731,15 @@ export const [isKeyboardConnected, isKeyboardConnectedSync] = getSupportedPlatfo
   defaultValue: false,
 });
 
-export const [getSupportedMediaTypeList, getSupportedMediaTypeListSync] = getSupportedPlatformInfoFunctions(
-  {
-    supportedPlatforms: ['android'],
-    getter: () => RNDeviceInfo.getSupportedMediaTypeList(),
-    syncGetter: () => RNDeviceInfo.getSupportedMediaTypeListSync(),
-    defaultValue: []
-  }
-)
-
+export const [
+  getSupportedMediaTypeList,
+  getSupportedMediaTypeListSync,
+] = getSupportedPlatformInfoFunctions({
+  supportedPlatforms: ['android'],
+  getter: () => RNDeviceInfo.getSupportedMediaTypeList(),
+  syncGetter: () => RNDeviceInfo.getSupportedMediaTypeListSync(),
+  defaultValue: [],
+});
 
 export const isTabletMode = () =>
   getSupportedPlatformInfoAsync({
@@ -851,11 +853,19 @@ export function useIsHeadphonesConnected(): AsyncHookResult<boolean> {
 }
 
 export function useIsWiredHeadphonesConnected(): AsyncHookResult<boolean> {
-  return useOnEvent('RNDeviceInfo_headphoneWiredConnectionDidChange', isWiredHeadphonesConnected, false);
+  return useOnEvent(
+    'RNDeviceInfo_headphoneWiredConnectionDidChange',
+    isWiredHeadphonesConnected,
+    false
+  );
 }
 
 export function useIsBluetoothHeadphonesConnected(): AsyncHookResult<boolean> {
-  return useOnEvent('RNDeviceInfo_headphoneBluetoothConnectionDidChange', isBluetoothHeadphonesConnected, false);
+  return useOnEvent(
+    'RNDeviceInfo_headphoneBluetoothConnectionDidChange',
+    isBluetoothHeadphonesConnected,
+    false
+  );
 }
 
 export function useFirstInstallTime(): AsyncHookResult<number> {
@@ -1064,7 +1074,7 @@ const DeviceInfo: DeviceInfoModule = {
   useIsBluetoothHeadphonesConnected,
   useBrightness,
   getSupportedMediaTypeList,
-  getSupportedMediaTypeListSync
+  getSupportedMediaTypeListSync,
 };
 
 export default DeviceInfo;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 import { DeviceInfoModule } from './internal/privateTypes';
 import type {
   AsyncHookResult,
+  AvailableCapacityType,
   DeviceType,
   LocationProviderInfo,
   PowerState,
@@ -529,8 +530,20 @@ export function getTotalDiskCapacityOldSync() {
 
 export const [getFreeDiskStorage, getFreeDiskStorageSync] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows', 'web'],
-  getter: () => RNDeviceInfo.getFreeDiskStorage(),
-  syncGetter: () => RNDeviceInfo.getFreeDiskStorageSync(),
+  getter: (storageType: AvailableCapacityType = 'total') => {
+    if (Platform.OS === 'ios') {
+      return RNDeviceInfo.getFreeDiskStorage(storageType);
+    } else {
+      return RNDeviceInfo.getFreeDiskStorage();
+    }
+  },
+  syncGetter: (storageType: AvailableCapacityType = 'total') => {
+    if (Platform.OS === 'ios') {
+      return RNDeviceInfo.getFreeDiskStorageSync(storageType);
+    } else {
+      return RNDeviceInfo.getFreeDiskStorageSync();
+    }
+  },
   defaultValue: -1,
 });
 

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -1,5 +1,11 @@
 import { Platform } from 'react-native';
-import type { DeviceType, LocationProviderInfo, PowerState, AsyncHookResult, AvailableCapacityType } from './types';
+import type {
+  DeviceType,
+  LocationProviderInfo,
+  PowerState,
+  AsyncHookResult,
+  AvailableCapacityType,
+} from './types';
 
 export type NotchDevice = {
   brand: string;

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import type { DeviceType, LocationProviderInfo, PowerState, AsyncHookResult } from './types';
+import type { DeviceType, LocationProviderInfo, PowerState, AsyncHookResult, AvailableCapacityType } from './types';
 
 export type NotchDevice = {
   brand: string;
@@ -69,9 +69,9 @@ interface ExposedNativeMethods {
   getFirstInstallTimeSync: () => number;
   getFontScale: () => Promise<number>;
   getFontScaleSync: () => number;
-  getFreeDiskStorage: () => Promise<number>;
+  getFreeDiskStorage: (storageType?: AvailableCapacityType) => Promise<number>;
   getFreeDiskStorageOld: () => Promise<number>;
-  getFreeDiskStorageSync: () => number;
+  getFreeDiskStorageSync: (storageType?: AvailableCapacityType) => number;
   getFreeDiskStorageOldSync: () => number;
   getHardware: () => Promise<string>;
   getHardwareSync: () => string;
@@ -209,7 +209,7 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   useBrightness: () => number | null;
 }
 
-export type Getter<T> = () => T;
+export type Getter<T> = (...args: any[]) => T;
 export type PlatformArray = typeof Platform.OS[];
 
 export interface GetSupportedPlatformInfoSyncParams<T> {

--- a/src/internal/supported-platform-info.ts
+++ b/src/internal/supported-platform-info.ts
@@ -92,7 +92,7 @@ export function getSupportedPlatformInfoFunctions<T>({
 }: GetSupportedPlatformInfoFunctionsParams<T>): [Getter<Promise<T>>, Getter<T>] {
   return [
     (...args: any[]) =>
-      getSupportedPlatformInfoAsync({ ...asyncParams }).then(() => asyncParams.getter(...args)),
+      getSupportedPlatformInfoAsync({ ...asyncParams, getter: () => asyncParams.getter(...args) }),
     (...args: any[]) =>
       getSupportedPlatformInfoSync({ ...asyncParams, getter: () => syncGetter(...args) }),
   ];

--- a/src/internal/supported-platform-info.ts
+++ b/src/internal/supported-platform-info.ts
@@ -91,7 +91,9 @@ export function getSupportedPlatformInfoFunctions<T>({
   ...asyncParams
 }: GetSupportedPlatformInfoFunctionsParams<T>): [Getter<Promise<T>>, Getter<T>] {
   return [
-    () => getSupportedPlatformInfoAsync(asyncParams),
-    () => getSupportedPlatformInfoSync({ ...asyncParams, getter: syncGetter }),
+    (...args: any[]) =>
+      getSupportedPlatformInfoAsync({ ...asyncParams }).then(() => asyncParams.getter(...args)),
+    (...args: any[]) =>
+      getSupportedPlatformInfoSync({ ...asyncParams, getter: () => syncGetter(...args) }),
   ];
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -17,3 +17,6 @@ export interface AsyncHookResult<T> {
   loading: boolean;
   result: T;
 }
+
+// Only relevant for iOS
+export type AvailableCapacityType = 'total' | 'important' | 'opportunistic';

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -123,7 +123,7 @@ export const getUserAgent = async () => {
 
 export const isBatteryCharging = async () => {
   if (navigator.getBattery) {
-    return navigator.getBattery().then(battery => battery.charging);
+    return navigator.getBattery().then((battery) => battery.charging);
   }
   return false;
 };
@@ -134,7 +134,7 @@ export const isBatteryChargingSync = () => {
 
 export const isCameraPresent = async () => {
   if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
-    return navigator.mediaDevices.enumerateDevices().then(devices => {
+    return navigator.mediaDevices.enumerateDevices().then((devices) => {
       return !!devices.find((d) => d.kind === 'videoinput');
     });
   }
@@ -150,7 +150,7 @@ export const isCameraPresentSync = () => {
 
 export const getBatteryLevel = async () => {
   if (navigator.getBattery) {
-    return navigator.getBattery().then(battery => battery.level);
+    return navigator.getBattery().then((battery) => battery.level);
   }
   return -1;
 };
@@ -173,7 +173,7 @@ export const getBaseOs = async () => {
 
 export const getTotalDiskCapacity = async () => {
   if (navigator.storage && navigator.storage.estimate) {
-    return navigator.storage.estimate().then(({ quota }) => quota)
+    return navigator.storage.estimate().then(({ quota }) => quota);
   }
   return -1;
 };
@@ -187,7 +187,7 @@ export const getTotalDiskCapacitySync = () => {
 
 export const getFreeDiskStorage = async () => {
   if (navigator.storage && navigator.storage.estimate) {
-    return navigator.storage.estimate().then(({ quota, usage }) => quota - usage)
+    return navigator.storage.estimate().then(({ quota, usage }) => quota - usage);
   }
   return -1;
 };
@@ -213,7 +213,7 @@ export const getTotalMemory = async () => {
 
 export const getPowerState = async () => {
   if (navigator.getBattery) {
-    return navigator.getBattery().then((battery) => _readPowerState(battery))
+    return navigator.getBattery().then((battery) => _readPowerState(battery));
   }
   return {};
 };


### PR DESCRIPTION
## Description

Fixes #1148

This issue has been closed, but no action has been taken afaik. 
Please let me know if you want me to open a new issue. 

Apple's suggestion on how to get storage capacity: https://developer.apple.com/documentation/foundation/urlresourcekey/checking_volume_storage_capacity

## Checklist

* [ X] I have tested this on a device/simulator for each compatible OS (note: I have only tested on iOS version 11+)
* [ NA] I added the documentation in `README.md` 
* [ NA] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [NA] I added a sample use of the API (`example/App.js`)
