### PR TITLE
docs(README): typo fix in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ The name of the hardware (from the kernel command line or /proc).
 ```js
 DeviceInfo.getHardware().then(hardware => {
   // "walleye"
-};
+});
 ```
 
 ---


### PR DESCRIPTION
Just a missing parenthesis that could mislead someone who is distracted