### PR TITLE
test(ci): define env vars needed by ubuntu-24 image

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -25,6 +25,9 @@ jobs:
     env:
       EMULATOR_COMMAND: "-avd TestingAVD -noaudio -gpu swiftshader_indirect -camera-back none -no-snapshot -no-window -no-boot-anim -nojni -memory 2048 -timezone 'Europe/London' -cores 2"
       EMULATOR_EXECUTABLE: qemu-system-x86_64-headless
+      ANDROID_USER_HOME: /home/runner/.android
+      ANDROID_EMULATOR_HOME: /home/runner/.android
+      ANDROID_AVD_HOME: /home/runner/.android/avd
     steps:
       - name: Liberate disk space
         uses: jlumbroso/free-disk-space@main


### PR DESCRIPTION
there is an interaction with other env vars defined on ubuntu-24 runner image that were not on ubuntu-22 that makes the avd create in an unwnanted directory

Simply defining the env vars may be sufficient, or I may need to create /home/runner/.android/avd directory as well, we will see