### PR TITLE
docs: Fix incorrect method referred to for v14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### BREAKING CHANGES
 
-* removed default fallback getDeviceId via play-services-iid dependency
+* removed default fallback getInstanceId via play-services-iid dependency
 
 This dependency has the unfortunate side effect of including AD_ID permission, which is
 not permissible for many types of applications.


### PR DESCRIPTION
The breaking change is currently written as affecting [`getDeviceId`](https://github.com/react-native-device-info/react-native-device-info?tab=readme-ov-file#getdeviceid) but it doesn't. [`getInstanceId`](https://github.com/react-native-device-info/react-native-device-info?tab=readme-ov-file#getinstanceid) is the affected method.

## Description

This is a documentation mistake in the `CHANGELOG.md` file originating from the change made in #1673. The [releases page](https://github.com/react-native-device-info/react-native-device-info/releases) also needs to be corrected but I don't have edit permission for that. Fixing this prevents developers from wasting their time and making a mistake auditing usage of the wrong method.

