### PR TITLE
fix(windows): Update RNDeviceInfoCPP.h for windows on ARM CPU arch on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1412,8 +1412,7 @@ Returns a list of supported processor architecture version
 
 ```js
 DeviceInfo.supportedAbis().then((abis) => {
-  // [ "arm64 v8", "Intel x86-64h Haswell", "arm64-v8a", "armeabi-v7a", "armeabi", "win_x86", "win_arm", "win_x64" ]
-});
+  // [ "arm64 v8", "Intel x86-64h Haswell", "arm64-v8a", "armeabi-v7a", "armeabi", "win_x86", "win_arm", "win_x64", "win_arm64", "win_x86onarm64" ]});
 ```
 
 ---

--- a/windows/code/RNDeviceInfoCPP.h
+++ b/windows/code/RNDeviceInfoCPP.h
@@ -109,6 +109,12 @@ namespace winrt::RNDeviceInfoCPP
             break;
         case Windows::System::ProcessorArchitecture::Neutral:
             arch = "neutral";
+	    break;
+        case Windows::System::ProcessorArchitecture::Arm64:
+            arch = "win_arm64";
+	    break;
+        case Windows::System::ProcessorArchitecture::X86OnArm64:
+            arch = "win_x86onarm64";
             break;
         default:
             arch = "unknown";


### PR DESCRIPTION
Updated Windows-on-ARM CPU architecture types for Windows in the existing `getSupportedAbis` API as per https://learn.microsoft.com/en-us/uwp/api/windows.system.processorarchitecture?view=winrt-26100#fields

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ✅     |

## Checklist


* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
