### PR TITLE
fix(tvos): Fix compilation issues due to missing apis in keyForStorageType for tvos (#1670)

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -37,9 +37,7 @@ typedef NS_ENUM(NSInteger, DeviceType) {
 @import CoreTelephony;
 #endif
 
-#if !TARGET_OS_TV
 @import Darwin.sys.sysctl;
-#endif
 
 @implementation RNDeviceInfo
 {
@@ -637,6 +635,9 @@ RCT_EXPORT_METHOD(getTotalDiskCapacity:(RCTPromiseResolveBlock)resolve rejecter:
 }
 
 - (NSString *)keyForStorageType:(NSString *)storageType {
+#if TARGET_OS_TV
+    return NSURLVolumeAvailableCapacityKey;
+#else
     if ([storageType isEqualToString:@"important"]) {
         return NSURLVolumeAvailableCapacityForImportantUsageKey;
     } else if ([storageType isEqualToString:@"opportunistic"]) {
@@ -644,6 +645,7 @@ RCT_EXPORT_METHOD(getTotalDiskCapacity:(RCTPromiseResolveBlock)resolve rejecter:
     } else {
         return NSURLVolumeAvailableCapacityKey;
     }
+#endif
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getFreeDiskStorageSync:(NSString *)storageType) {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

- Fixes #1670. Apis are [not available for tvos](https://developer.apple.com/documentation/foundation/urlresourcekey/checking_volume_storage_capacity).
- Fixes compilation issue: `sysctl` needs to be imported for tvos as well.

<!-- OR, if you're implementing a new feature: -->

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
