### PR TITLE
fix(android): quiet a build warning for users

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -197,6 +197,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   // the upstream method was removed in react-native 0.74
   // this stub remains for backwards compatibility so that react-native < 0.74
   // (which will still call onCatalystInstanceDestroy) will continue to function
+  @SuppressWarnings({"deprecation", "removal"})
   public void onCatalystInstanceDestroy() {
     invalidate();
   }


### PR DESCRIPTION

## Description

we already handle the onCatalystInstanceDestroy method deprecation pretty well, but we get build warnings for even keeping the old API, though we do that on purpose for backwards-compatibility

So suppress those build warnings since they look worrisome but are not actionable

There was one poster that mentioned it, and I noticed it as well in my own usage of the module:

- Fixes #1689

## Tests

I checked compiling this against a really old react-native (the example here being so out of date actually helped! CI will show it as well) and I tested it against a modern react-native where the warning was generated. Both still worked, so I think this is backwards- and forwards-compatible

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
