### PR TITLE
fix(ios): Added iPhone 16e device identifier

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -260,6 +260,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone17,2": @"iPhone 16 Pro Max",
         @"iPhone17,3": @"iPhone 16",
         @"iPhone17,4": @"iPhone 16 Plus",
+        @"iPhone17,5": @"iPhone 16e",
 
         @"iPod1,1": @"iPod Touch", // (Original)
         @"iPod2,1": @"iPod Touch", // (Second Generation)

--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -7,6 +7,10 @@ const devicesWithNotch: NotchDevice[] = [
   },
   {
     brand: 'Apple',
+    model: 'iPhone 16e',
+  },
+  {
+    brand: 'Apple',
     model: 'iPhone 16 Plus',
   },
   {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #1697

Without this, the iPhone 16e is not recognized as a device with a notch.
Note: This device does not have the dynamic island.

Until this PR is merged and released you can manually catch this with something like:
```
function getDoesDeviceHaveNotch() {
  if (DeviceInfo.getDeviceId().includes('iPhone17,5')) {
    return true;
  }
  return DeviceInfo.hasNotch();
}
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
