### PR TITLE
fix(android): Resolve NullPointerException in hasKeyboard function

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -127,7 +127,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
           updatedPowerState.putString(BATTERY_STATE, batteryState);
           updatedPowerState.putDouble(BATTERY_LEVEL, batteryLevel);
           updatedPowerState.putBoolean(LOW_POWER_MODE, powerSaveState);
-          
+
           sendEvent(getReactApplicationContext(), "RNDeviceInfo_powerStateDidChange", updatedPowerState);
           mLastBatteryState = batteryState;
           mLastPowerSaveState = powerSaveState;
@@ -1113,8 +1113,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     List<InputMethodInfo> inputMethodList = this.inputMethodManager.getEnabledInputMethodList();
     if (inputMethodList != null && !inputMethodList.isEmpty()) {
       for (InputMethodInfo inputMethodInfo : inputMethodList) {
-        String serviceName = inputMethodInfo.getServiceName().toLowerCase();
-        String id = inputMethodInfo.getId().toLowerCase();
+        String serviceName = inputMethodInfo.getServiceName() != null ? inputMethodInfo.getServiceName().toLowerCase() : "";
+        String id = inputMethodInfo.getId() != null ? inputMethodInfo.getId().toLowerCase() : "";
         if (serviceName.contains(name.toLowerCase()) || id.contains(name.toLowerCase())) {
           return true;
         }


### PR DESCRIPTION
## Description

Change `hasKeyboard` to use empty strings for comparison when `getServiceName()` or `getId()` are null. In the case that `inputMethodInfo` has no service name or id, `hasKeyboard` throws a `NullPointerException`.

Fixes react-native-device-info/react-native-device-info#1722
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
