### PR TITLE
feat(ios): add missing iPhone 17 device names

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -260,6 +260,11 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone17,2": @"iPhone 16 Pro Max",
         @"iPhone17,3": @"iPhone 16",
         @"iPhone17,4": @"iPhone 16 Plus",
+        @"iPhone17,5": @"iPhone 16e",
+        @"iPhone18,1": @"iPhone 17 Pro",
+        @"iPhone18,2": @"iPhone 17 Pro Max",
+        @"iPhone18,3": @"iPhone 17",
+        @"iPhone18,4": @"iPhone Air",
 
         @"iPod1,1": @"iPod Touch", // (Original)
         @"iPod2,1": @"iPod Touch", // (Second Generation)

--- a/src/internal/devicesWithDynamicIsland.ts
+++ b/src/internal/devicesWithDynamicIsland.ts
@@ -3,6 +3,22 @@ import { NotchDevice } from './privateTypes';
 const devicesWithDynamicIsland: NotchDevice[] = [
   {
     brand: 'Apple',
+    model: 'iPhone 17',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone Air',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 17 Pro',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 17 Pro Max',
+  },
+  {
+    brand: 'Apple',
     model: 'iPhone 16',
   },
   {

--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -3,6 +3,26 @@ import { NotchDevice } from './privateTypes';
 const devicesWithNotch: NotchDevice[] = [
   {
     brand: 'Apple',
+    model: 'iPhone 17',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone Air',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 17 Pro',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 17 Pro Max',
+  },
+  {
+    brand: 'Apple',
+    model: 'iPhone 16e',
+  },
+  {
+    brand: 'Apple',
     model: 'iPhone 16',
   },
   {


### PR DESCRIPTION
## Description

* (feat: Add device names for iPhone 17 family)
* fix(ios): re-order device name list / add missing devices

this makes it the exact same order as the apparently-canonical gist:
https://gist.github.com/adamawolf/3048717

@mikehardy ping

https://github.com/react-native-device-info/react-native-device-info/issues/1725
https://github.com/react-native-device-info/react-native-device-info/issues/1717