### PR TITLE
docs: adding typedoc

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,45 @@
+name: docs-pages
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+      - name: Install dependencies
+        run:  yarn ci:install
+      - name: Build docs
+        run: yarn docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ example/*.binlog
 
 # Debug log
 example/debug.log
+
+docs/

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "build": "bob build",
     "prepare": "bob build",
     "ci:install": "rm -rf ./node_modules && yarn install --frozen-lockfile",
-    "ci:shipit": "release-it --ci"
+    "ci:shipit": "release-it --ci",
+    "docs": "npx typedoc",
+    "docs:serve": "npx http-server docs"
   },
   "lint-staged": {
     "*.ts": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,15 +19,48 @@ import type {
   AppSetIdInfo,
 } from './internal/types';
 
-export const [getUniqueId, getUniqueIdSync] = getSupportedPlatformInfoFunctions({
+const [getUniqueIdInternal, getUniqueIdSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'uniqueId',
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.getUniqueId(),
   syncGetter: () => RNDeviceInfo.getUniqueIdSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the unique ID information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getUniqueId();
+ * ```
+ */
+export const getUniqueId = getUniqueIdInternal;
+/**
+ * Synchronous variant of {@link getUniqueId}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getUniqueIdSync();
+ * ```
+ */
+export const getUniqueIdSync = getUniqueIdSyncInternal;
 
 let uniqueId: string;
+/**
+ * Preloads the unique ID on iOS so that {@link getUniqueId} can resolve synchronously later in the app lifecycle.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await syncUniqueId();
+ * ```
+ */
 export async function syncUniqueId() {
   if (Platform.OS === 'ios') {
     uniqueId = await RNDeviceInfo.syncUniqueId();
@@ -37,30 +70,106 @@ export async function syncUniqueId() {
   return uniqueId;
 }
 
-export const [getInstanceId, getInstanceIdSync] = getSupportedPlatformInfoFunctions({
+const [getInstanceIdInternal, getInstanceIdSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'instanceId',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getInstanceId(),
   syncGetter: () => RNDeviceInfo.getInstanceIdSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the instance ID information reported by the native platform.
+ * @example
+ * ```ts
+ * const result = await getInstanceId();
+ * ```
+ */
+export const getInstanceId = getInstanceIdInternal;
+/**
+ * Synchronous variant of {@link getInstanceId}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getInstanceIdSync();
+ * ```
+ */
+export const getInstanceIdSync = getInstanceIdSyncInternal;
 
-export const [getSerialNumber, getSerialNumberSync] = getSupportedPlatformInfoFunctions({
+const [getSerialNumberInternal, getSerialNumberSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'serialNumber',
   supportedPlatforms: ['android', 'windows'],
   getter: () => RNDeviceInfo.getSerialNumber(),
   syncGetter: () => RNDeviceInfo.getSerialNumberSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the serial number information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getSerialNumber();
+ * ```
+ */
+export const getSerialNumber = getSerialNumberInternal;
+/**
+ * Synchronous variant of {@link getSerialNumber}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getSerialNumberSync();
+ * ```
+ */
+export const getSerialNumberSync = getSerialNumberSyncInternal;
 
-export const [getAndroidId, getAndroidIdSync] = getSupportedPlatformInfoFunctions({
+const [getAndroidIdInternal, getAndroidIdSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'androidId',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getAndroidId(),
   syncGetter: () => RNDeviceInfo.getAndroidIdSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the Android ID information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getAndroidId();
+ * ```
+ */
+export const getAndroidId = getAndroidIdInternal;
+/**
+ * Synchronous variant of {@link getAndroidId}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getAndroidIdSync();
+ * ```
+ */
+export const getAndroidIdSync = getAndroidIdSyncInternal;
 
+/**
+ * Retrieves the app set ID information reported by the native platform.
+ *
+ *![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getAppSetId();
+ * ```
+ */
 export const getAppSetId = () =>
   getSupportedPlatformInfoAsync({
     memoKey: 'appSetId',
@@ -69,20 +178,76 @@ export const getAppSetId = () =>
     getter: () => RNDeviceInfo.getAppSetId(),
   });
 
-export const [getIpAddress, getIpAddressSync] = getSupportedPlatformInfoFunctions({
+const [getIpAddressInternal, getIpAddressSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.getIpAddress(),
   syncGetter: () => RNDeviceInfo.getIpAddressSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the IP address information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getIpAddress();
+ * ```
+ */
+export const getIpAddress = getIpAddressInternal;
+/**
+ * Synchronous variant of {@link getIpAddress}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getIpAddressSync();
+ * ```
+ */
+export const getIpAddressSync = getIpAddressSyncInternal;
 
-export const [isCameraPresent, isCameraPresentSync] = getSupportedPlatformInfoFunctions({
+const [isCameraPresentInternal, isCameraPresentSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'windows', 'web'],
   getter: () => RNDeviceInfo.isCameraPresent(),
   syncGetter: () => RNDeviceInfo.isCameraPresentSync(),
   defaultValue: false,
 });
+/**
+ * Returns true when at least one hardware camera is available on the device.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isCameraPresent();
+ * ```
+ */
+export const isCameraPresent = isCameraPresentInternal;
+/**
+ * Synchronous variant of {@link isCameraPresent}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isCameraPresentSync();
+ * ```
+ */
+export const isCameraPresentSync = isCameraPresentSyncInternal;
 
+/**
+ * Retrieves the WiFi MAC address on Android and returns a constant placeholder for other platforms.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getMacAddress();
+ * ```
+ */
 export async function getMacAddress() {
   if (Platform.OS === 'android') {
     return RNDeviceInfo.getMacAddress();
@@ -92,6 +257,14 @@ export async function getMacAddress() {
   return 'unknown';
 }
 
+/**
+ * Synchronous variant of {@link getMacAddress}.
+ *
+ * @example
+ * ```ts
+ * const result = getMacAddressSync();
+ * ```
+ */
 export function getMacAddressSync() {
   if (Platform.OS === 'android') {
     return RNDeviceInfo.getMacAddressSync();
@@ -101,6 +274,16 @@ export function getMacAddressSync() {
   return 'unknown';
 }
 
+/**
+ * Retrieves the device ID information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getDeviceId();
+ * ```
+ */
 export const getDeviceId = () =>
   getSupportedPlatformInfoSync({
     defaultValue: 'unknown',
@@ -109,7 +292,7 @@ export const getDeviceId = () =>
     supportedPlatforms: ['android', 'ios', 'windows'],
   });
 
-export const [getManufacturer, getManufacturerSync] = getSupportedPlatformInfoFunctions({
+const [getManufacturerInternal, getManufacturerSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'manufacturer',
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () =>
@@ -117,7 +300,40 @@ export const [getManufacturer, getManufacturerSync] = getSupportedPlatformInfoFu
   syncGetter: () => (Platform.OS == 'ios' ? 'Apple' : RNDeviceInfo.getSystemManufacturerSync()),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the manufacturer information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getManufacturer();
+ * ```
+ */
+export const getManufacturer = getManufacturerInternal;
+/**
+ * Synchronous variant of {@link getManufacturer}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getManufacturerSync();
+ * ```
+ */
+export const getManufacturerSync = getManufacturerSyncInternal;
 
+/**
+ * Retrieves the model information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getModel();
+ * ```
+ */
 export const getModel = () =>
   getSupportedPlatformInfoSync({
     memoKey: 'model',
@@ -126,6 +342,16 @@ export const getModel = () =>
     getter: () => RNDeviceInfo.model,
   });
 
+/**
+ * Retrieves the brand information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getBrand();
+ * ```
+ */
 export const getBrand = () =>
   getSupportedPlatformInfoSync({
     memoKey: 'brand',
@@ -134,6 +360,16 @@ export const getBrand = () =>
     getter: () => RNDeviceInfo.brand,
   });
 
+/**
+ * Retrieves the system name information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getSystemName();
+ * ```
+ */
 export const getSystemName = () =>
   getSupportedPlatformInfoSync({
     defaultValue: 'unknown',
@@ -148,6 +384,16 @@ export const getSystemName = () =>
       }),
   });
 
+/**
+ * Retrieves the system version information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getSystemVersion();
+ * ```
+ */
 export const getSystemVersion = () =>
   getSupportedPlatformInfoSync({
     defaultValue: 'unknown',
@@ -156,22 +402,78 @@ export const getSystemVersion = () =>
     memoKey: 'systemVersion',
   });
 
-export const [getBuildId, getBuildIdSync] = getSupportedPlatformInfoFunctions({
+const [getBuildIdInternal, getBuildIdSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'buildId',
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.getBuildId(),
   syncGetter: () => RNDeviceInfo.getBuildIdSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the build ID information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getBuildId();
+ * ```
+ */
+export const getBuildId = getBuildIdInternal;
+/**
+ * Synchronous variant of {@link getBuildId}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getBuildIdSync();
+ * ```
+ */
+export const getBuildIdSync = getBuildIdSyncInternal;
 
-export const [getApiLevel, getApiLevelSync] = getSupportedPlatformInfoFunctions({
+const [getApiLevelInternal, getApiLevelSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'apiLevel',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getApiLevel(),
   syncGetter: () => RNDeviceInfo.getApiLevelSync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the API level information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getApiLevel();
+ * ```
+ */
+export const getApiLevel = getApiLevelInternal;
+/**
+ * Synchronous variant of {@link getApiLevel}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getApiLevelSync();
+ * ```
+ */
+export const getApiLevelSync = getApiLevelSyncInternal;
 
+/**
+ * Retrieves the bundle ID information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getBundleId();
+ * ```
+ */
 export const getBundleId = () =>
   getSupportedPlatformInfoSync({
     memoKey: 'bundleId',
@@ -180,9 +482,9 @@ export const getBundleId = () =>
     getter: () => RNDeviceInfo.bundleId,
   });
 
-export const [
-  getInstallerPackageName,
-  getInstallerPackageNameSync,
+const [
+  getInstallerPackageNameInternal,
+  getInstallerPackageNameSyncInternal,
 ] = getSupportedPlatformInfoFunctions({
   memoKey: 'installerPackageName',
   supportedPlatforms: ['android', 'windows', 'ios'],
@@ -190,7 +492,40 @@ export const [
   syncGetter: () => RNDeviceInfo.getInstallerPackageNameSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the installer package name information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getInstallerPackageName();
+ * ```
+ */
+export const getInstallerPackageName = getInstallerPackageNameInternal;
+/**
+ * Synchronous variant of {@link getInstallerPackageName}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getInstallerPackageNameSync();
+ * ```
+ */
+export const getInstallerPackageNameSync = getInstallerPackageNameSyncInternal;
 
+/**
+ * Retrieves the application name information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getApplicationName();
+ * ```
+ */
 export const getApplicationName = () =>
   getSupportedPlatformInfoSync({
     memoKey: 'appName',
@@ -199,6 +534,16 @@ export const getApplicationName = () =>
     supportedPlatforms: ['android', 'ios', 'windows'],
   });
 
+/**
+ * Retrieves the build number information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getBuildNumber();
+ * ```
+ */
 export const getBuildNumber = () =>
   getSupportedPlatformInfoSync({
     memoKey: 'buildNumber',
@@ -207,6 +552,16 @@ export const getBuildNumber = () =>
     defaultValue: 'unknown',
   });
 
+/**
+ * Retrieves the version information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getVersion();
+ * ```
+ */
 export const getVersion = () =>
   getSupportedPlatformInfoSync({
     memoKey: 'version',
@@ -215,24 +570,90 @@ export const getVersion = () =>
     getter: () => RNDeviceInfo.appVersion,
   });
 
+/**
+ * Retrieves the readable version information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getReadableVersion();
+ * ```
+ */
 export function getReadableVersion() {
   return getVersion() + '.' + getBuildNumber();
 }
 
-export const [getDeviceName, getDeviceNameSync] = getSupportedPlatformInfoFunctions({
+const [getDeviceNameInternal, getDeviceNameSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.getDeviceName(),
   syncGetter: () => RNDeviceInfo.getDeviceNameSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the device name information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getDeviceName();
+ * ```
+ */
+export const getDeviceName = getDeviceNameInternal;
+/**
+ * Synchronous variant of {@link getDeviceName}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getDeviceNameSync();
+ * ```
+ */
+export const getDeviceNameSync = getDeviceNameSyncInternal;
 
-export const [getUsedMemory, getUsedMemorySync] = getSupportedPlatformInfoFunctions({
+const [getUsedMemoryInternal, getUsedMemorySyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows', 'web'],
   getter: () => RNDeviceInfo.getUsedMemory(),
   syncGetter: () => RNDeviceInfo.getUsedMemorySync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the used memory information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getUsedMemory();
+ * ```
+ */
+export const getUsedMemory = getUsedMemoryInternal;
+/**
+ * Synchronous variant of {@link getUsedMemory}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getUsedMemorySync();
+ * ```
+ */
+export const getUsedMemorySync = getUsedMemorySyncInternal;
 
+/**
+ * Retrieves the user agent information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getUserAgent();
+ * ```
+ */
 export const getUserAgent = () =>
   getSupportedPlatformInfoAsync({
     memoKey: 'userAgent',
@@ -241,6 +662,16 @@ export const getUserAgent = () =>
     getter: () => RNDeviceInfo.getUserAgent(),
   });
 
+/**
+ * Synchronous variant of {@link getUserAgent}.
+ *
+ *![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getUserAgentSync();
+ * ```
+ */
 export const getUserAgentSync = () =>
   getSupportedPlatformInfoSync({
     memoKey: 'userAgentSync',
@@ -249,141 +680,542 @@ export const getUserAgentSync = () =>
     getter: () => RNDeviceInfo.getUserAgentSync(),
   });
 
-export const [getFontScale, getFontScaleSync] = getSupportedPlatformInfoFunctions({
+const [getFontScaleInternal, getFontScaleSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.getFontScale(),
   syncGetter: () => RNDeviceInfo.getFontScaleSync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the font scale information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getFontScale();
+ * ```
+ */
+export const getFontScale = getFontScaleInternal;
+/**
+ * Synchronous variant of {@link getFontScale}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getFontScaleSync();
+ * ```
+ */
+export const getFontScaleSync = getFontScaleSyncInternal;
 
-export const [getBootloader, getBootloaderSync] = getSupportedPlatformInfoFunctions({
+const [getBootloaderInternal, getBootloaderSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'bootloader',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getBootloader(),
   syncGetter: () => RNDeviceInfo.getBootloaderSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the bootloader information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getBootloader();
+ * ```
+ */
+export const getBootloader = getBootloaderInternal;
+/**
+ * Synchronous variant of {@link getBootloader}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getBootloaderSync();
+ * ```
+ */
+export const getBootloaderSync = getBootloaderSyncInternal;
 
-export const [getDevice, getDeviceSync] = getSupportedPlatformInfoFunctions({
+const [getDeviceInternal, getDeviceSyncInternal] = getSupportedPlatformInfoFunctions({
   getter: () => RNDeviceInfo.getDevice(),
   syncGetter: () => RNDeviceInfo.getDeviceSync(),
   defaultValue: 'unknown',
   memoKey: 'device',
   supportedPlatforms: ['android'],
 });
+/**
+ * Retrieves the device information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getDevice();
+ * ```
+ */
+export const getDevice = getDeviceInternal;
+/**
+ * Synchronous variant of {@link getDevice}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getDeviceSync();
+ * ```
+ */
+export const getDeviceSync = getDeviceSyncInternal;
 
-export const [getDisplay, getDisplaySync] = getSupportedPlatformInfoFunctions({
+const [getDisplayInternal, getDisplaySyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'display',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getDisplay(),
   syncGetter: () => RNDeviceInfo.getDisplaySync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the display information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getDisplay();
+ * ```
+ */
+export const getDisplay = getDisplayInternal;
+/**
+ * Synchronous variant of {@link getDisplay}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getDisplaySync();
+ * ```
+ */
+export const getDisplaySync = getDisplaySyncInternal;
 
-export const [getFingerprint, getFingerprintSync] = getSupportedPlatformInfoFunctions({
+const [getFingerprintInternal, getFingerprintSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'fingerprint',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getFingerprint(),
   syncGetter: () => RNDeviceInfo.getFingerprintSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the fingerprint information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getFingerprint();
+ * ```
+ */
+export const getFingerprint = getFingerprintInternal;
+/**
+ * Synchronous variant of {@link getFingerprint}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getFingerprintSync();
+ * ```
+ */
+export const getFingerprintSync = getFingerprintSyncInternal;
 
-export const [getHardware, getHardwareSync] = getSupportedPlatformInfoFunctions({
+const [getHardwareInternal, getHardwareSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'hardware',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getHardware(),
   syncGetter: () => RNDeviceInfo.getHardwareSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the hardware information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getHardware();
+ * ```
+ */
+export const getHardware = getHardwareInternal;
+/**
+ * Synchronous variant of {@link getHardware}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getHardwareSync();
+ * ```
+ */
+export const getHardwareSync = getHardwareSyncInternal;
 
-export const [getHost, getHostSync] = getSupportedPlatformInfoFunctions({
+const [getHostInternal, getHostSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'host',
   supportedPlatforms: ['android', 'windows'],
   getter: () => RNDeviceInfo.getHost(),
   syncGetter: () => RNDeviceInfo.getHostSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the host information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getHost();
+ * ```
+ */
+export const getHost = getHostInternal;
+/**
+ * Synchronous variant of {@link getHost}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getHostSync();
+ * ```
+ */
+export const getHostSync = getHostSyncInternal;
 
-export const [getHostNames, getHostNamesSync] = getSupportedPlatformInfoFunctions({
+const [getHostNamesInternal, getHostNamesSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'hostNames',
   supportedPlatforms: ['windows'],
   getter: () => RNDeviceInfo.getHostNames(),
   syncGetter: () => RNDeviceInfo.getHostNamesSync(),
   defaultValue: [] as string[],
 });
+/**
+ * Retrieves the host names information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getHostNames();
+ * ```
+ */
+export const getHostNames = getHostNamesInternal;
+/**
+ * Synchronous variant of {@link getHostNames}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getHostNamesSync();
+ * ```
+ */
+export const getHostNamesSync = getHostNamesSyncInternal;
 
-export const [getProduct, getProductSync] = getSupportedPlatformInfoFunctions({
+const [getProductInternal, getProductSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'product',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getProduct(),
   syncGetter: () => RNDeviceInfo.getProductSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the product information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getProduct();
+ * ```
+ */
+export const getProduct = getProductInternal;
+/**
+ * Synchronous variant of {@link getProduct}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getProductSync();
+ * ```
+ */
+export const getProductSync = getProductSyncInternal;
 
-export const [getTags, getTagsSync] = getSupportedPlatformInfoFunctions({
+const [getTagsInternal, getTagsSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'tags',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getTags(),
   syncGetter: () => RNDeviceInfo.getTagsSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the tags information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getTags();
+ * ```
+ */
+export const getTags = getTagsInternal;
+/**
+ * Synchronous variant of {@link getTags}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getTagsSync();
+ * ```
+ */
+export const getTagsSync = getTagsSyncInternal;
 
-export const [getType, getTypeSync] = getSupportedPlatformInfoFunctions({
+const [getTypeInternal, getTypeSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'type',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getType(),
   syncGetter: () => RNDeviceInfo.getTypeSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the type information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getType();
+ * ```
+ */
+export const getType = getTypeInternal;
+/**
+ * Synchronous variant of {@link getType}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getTypeSync();
+ * ```
+ */
+export const getTypeSync = getTypeSyncInternal;
 
-export const [getBaseOs, getBaseOsSync] = getSupportedPlatformInfoFunctions({
+const [getBaseOsInternal, getBaseOsSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'baseOs',
   supportedPlatforms: ['android', 'web', 'windows'],
   getter: () => RNDeviceInfo.getBaseOs(),
   syncGetter: () => RNDeviceInfo.getBaseOsSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the base OS information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getBaseOs();
+ * ```
+ */
+export const getBaseOs = getBaseOsInternal;
+/**
+ * Synchronous variant of {@link getBaseOs}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getBaseOsSync();
+ * ```
+ */
+export const getBaseOsSync = getBaseOsSyncInternal;
 
-export const [getPreviewSdkInt, getPreviewSdkIntSync] = getSupportedPlatformInfoFunctions({
+const [getPreviewSdkIntInternal, getPreviewSdkIntSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'previewSdkInt',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getPreviewSdkInt(),
   syncGetter: () => RNDeviceInfo.getPreviewSdkIntSync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the preview SDK int information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getPreviewSdkInt();
+ * ```
+ */
+export const getPreviewSdkInt = getPreviewSdkIntInternal;
+/**
+ * Synchronous variant of {@link getPreviewSdkInt}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getPreviewSdkIntSync();
+ * ```
+ */
+export const getPreviewSdkIntSync = getPreviewSdkIntSyncInternal;
 
-export const [getSecurityPatch, getSecurityPatchSync] = getSupportedPlatformInfoFunctions({
+const [getSecurityPatchInternal, getSecurityPatchSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'securityPatch',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getSecurityPatch(),
   syncGetter: () => RNDeviceInfo.getSecurityPatchSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the security patch information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getSecurityPatch();
+ * ```
+ */
+export const getSecurityPatch = getSecurityPatchInternal;
+/**
+ * Synchronous variant of {@link getSecurityPatch}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getSecurityPatchSync();
+ * ```
+ */
+export const getSecurityPatchSync = getSecurityPatchSyncInternal;
 
-export const [getCodename, getCodenameSync] = getSupportedPlatformInfoFunctions({
+const [getCodenameInternal, getCodenameSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'codeName',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getCodename(),
   syncGetter: () => RNDeviceInfo.getCodenameSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the codename information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getCodename();
+ * ```
+ */
+export const getCodename = getCodenameInternal;
+/**
+ * Synchronous variant of {@link getCodename}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getCodenameSync();
+ * ```
+ */
+export const getCodenameSync = getCodenameSyncInternal;
 
-export const [getIncremental, getIncrementalSync] = getSupportedPlatformInfoFunctions({
+const [getIncrementalInternal, getIncrementalSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'incremental',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getIncremental(),
   syncGetter: () => RNDeviceInfo.getIncrementalSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the incremental information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getIncremental();
+ * ```
+ */
+export const getIncremental = getIncrementalInternal;
+/**
+ * Synchronous variant of {@link getIncremental}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getIncrementalSync();
+ * ```
+ */
+export const getIncrementalSync = getIncrementalSyncInternal;
 
-export const [isEmulator, isEmulatorSync] = getSupportedPlatformInfoFunctions({
+const [isEmulatorInternal, isEmulatorSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'emulator',
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.isEmulator(),
   syncGetter: () => RNDeviceInfo.isEmulatorSync(),
   defaultValue: false,
 });
+/**
+ * Returns true when the current runtime is an emulator or simulator.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isEmulator();
+ * ```
+ */
+export const isEmulator = isEmulatorInternal;
+/**
+ * Synchronous variant of {@link isEmulator}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isEmulatorSync();
+ * ```
+ */
+export const isEmulatorSync = isEmulatorSyncInternal;
 
+/**
+ * Returns true when the device is classified as a tablet by the native OS.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isTablet();
+ * ```
+ */
 export const isTablet = () =>
   getSupportedPlatformInfoSync({
     defaultValue: false,
@@ -392,6 +1224,16 @@ export const isTablet = () =>
     getter: () => RNDeviceInfo.isTablet,
   });
 
+/**
+ * Returns true on Android devices that declare the low-RAM flag.
+ *
+ *![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isLowRamDevice();
+ * ```
+ */
 export const isLowRamDevice = () =>
   getSupportedPlatformInfoSync({
     defaultValue: false,
@@ -400,6 +1242,16 @@ export const isLowRamDevice = () =>
     getter: () => RNDeviceInfo.isLowRamDevice,
   });
 
+/**
+ * Returns true when Display Zoom is enabled on iOS.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isDisplayZoomed();
+ * ```
+ */
 export const isDisplayZoomed = () =>
   getSupportedPlatformInfoSync({
     defaultValue: false,
@@ -408,7 +1260,7 @@ export const isDisplayZoomed = () =>
     getter: () => RNDeviceInfo.isDisplayZoomed,
   });
 
-export const [isPinOrFingerprintSet, isPinOrFingerprintSetSync] = getSupportedPlatformInfoFunctions(
+const [isPinOrFingerprintSetInternal, isPinOrFingerprintSetSyncInternal] = getSupportedPlatformInfoFunctions(
   {
     supportedPlatforms: ['android', 'ios', 'windows'],
     getter: () => RNDeviceInfo.isPinOrFingerprintSet(),
@@ -416,8 +1268,41 @@ export const [isPinOrFingerprintSet, isPinOrFingerprintSetSync] = getSupportedPl
     defaultValue: false,
   }
 );
+/**
+ * Returns true when the user has configured any secure lock method such as a PIN or biometric.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isPinOrFingerprintSet();
+ * ```
+ */
+export const isPinOrFingerprintSet = isPinOrFingerprintSetInternal;
+/**
+ * Synchronous variant of {@link isPinOrFingerprintSet}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isPinOrFingerprintSetSync();
+ * ```
+ */
+export const isPinOrFingerprintSetSync = isPinOrFingerprintSetSyncInternal;
 
 let notch: boolean;
+/**
+ * Checks the current device against a curated list to determine if a screen notch is present.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = hasNotch();
+ * ```
+ */
 export function hasNotch() {
   if (notch === undefined) {
     let _brand = getBrand();
@@ -433,6 +1318,16 @@ export function hasNotch() {
 }
 
 let dynamicIsland: boolean;
+/**
+ * Determines whether the iOS device ships with a Dynamic Island cutout.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = hasDynamicIsland();
+ * ```
+ */
 export function hasDynamicIsland() {
   if (dynamicIsland === undefined) {
     let _brand = getBrand();
@@ -447,82 +1342,319 @@ export function hasDynamicIsland() {
   return dynamicIsland;
 }
 
-export const [hasGms, hasGmsSync] = getSupportedPlatformInfoFunctions({
+const [hasGmsInternal, hasGmsSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.hasGms(),
   syncGetter: () => RNDeviceInfo.hasGmsSync(),
   defaultValue: false,
 });
+/**
+ * Reports whether the device has GMS support.
+ *
+ *![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await hasGms();
+ * ```
+ */
+export const hasGms = hasGmsInternal;
+/**
+ * Synchronous variant of {@link hasGms}.
+ *
+ * @example
+ * ```ts
+ * const result = hasGmsSync();
+ * ```
+ */
+export const hasGmsSync = hasGmsSyncInternal;
 
-export const [hasHms, hasHmsSync] = getSupportedPlatformInfoFunctions({
+const [hasHmsInternal, hasHmsSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.hasHms(),
   syncGetter: () => RNDeviceInfo.hasHmsSync(),
   defaultValue: false,
 });
+/**
+ * Reports whether the device has HMS support.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await hasHms();
+ * ```
+ */
+export const hasHms = hasHmsInternal;
+/**
+ * Synchronous variant of {@link hasHms}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = hasHmsSync();
+ * ```
+ */
+export const hasHmsSync = hasHmsSyncInternal;
 
-export const [getFirstInstallTime, getFirstInstallTimeSync] = getSupportedPlatformInfoFunctions({
+const [getFirstInstallTimeInternal, getFirstInstallTimeSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'firstInstallTime',
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.getFirstInstallTime(),
   syncGetter: () => RNDeviceInfo.getFirstInstallTimeSync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the first install time information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getFirstInstallTime();
+ * ```
+ */
+export const getFirstInstallTime = getFirstInstallTimeInternal;
+/**
+ * Synchronous variant of {@link getFirstInstallTime}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getFirstInstallTimeSync();
+ * ```
+ */
+export const getFirstInstallTimeSync = getFirstInstallTimeSyncInternal;
 
-export const [getInstallReferrer, getInstallReferrerSync] = getSupportedPlatformInfoFunctions({
+const [getInstallReferrerInternal, getInstallReferrerSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'installReferrer',
   supportedPlatforms: ['android', 'windows', 'web'],
   getter: () => RNDeviceInfo.getInstallReferrer(),
   syncGetter: () => RNDeviceInfo.getInstallReferrerSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the install referrer information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getInstallReferrer();
+ * ```
+ */
+export const getInstallReferrer = getInstallReferrerInternal;
+/**
+ * Synchronous variant of {@link getInstallReferrer}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getInstallReferrerSync();
+ * ```
+ */
+export const getInstallReferrerSync = getInstallReferrerSyncInternal;
 
-export const [getLastUpdateTime, getLastUpdateTimeSync] = getSupportedPlatformInfoFunctions({
+const [getLastUpdateTimeInternal, getLastUpdateTimeSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'lastUpdateTime',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getLastUpdateTime(),
   syncGetter: () => RNDeviceInfo.getLastUpdateTimeSync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the last update time information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getLastUpdateTime();
+ * ```
+ */
+export const getLastUpdateTime = getLastUpdateTimeInternal;
+/**
+ * Synchronous variant of {@link getLastUpdateTime}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getLastUpdateTimeSync();
+ * ```
+ */
+export const getLastUpdateTimeSync = getLastUpdateTimeSyncInternal;
 
-export const [getStartupTime, getStartupTimeSync] = getSupportedPlatformInfoFunctions({
+const [getStartupTimeInternal, getStartupTimeSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'startupTime',
   supportedPlatforms: ['android', 'ios'],
   getter: () => RNDeviceInfo.getStartupTime(),
   syncGetter: () => RNDeviceInfo.getStartupTimeSync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the startup time information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getStartupTime();
+ * ```
+ */
+export const getStartupTime = getStartupTimeInternal;
+/**
+ * Synchronous variant of {@link getStartupTime}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getStartupTimeSync();
+ * ```
+ */
+export const getStartupTimeSync = getStartupTimeSyncInternal;
 
-export const [getCarrier, getCarrierSync] = getSupportedPlatformInfoFunctions({
+const [getCarrierInternal, getCarrierSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios'],
   getter: () => RNDeviceInfo.getCarrier(),
   syncGetter: () => RNDeviceInfo.getCarrierSync(),
   defaultValue: 'unknown',
 });
+/**
+ * Retrieves the carrier information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getCarrier();
+ * ```
+ */
+export const getCarrier = getCarrierInternal;
+/**
+ * Synchronous variant of {@link getCarrier}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getCarrierSync();
+ * ```
+ */
+export const getCarrierSync = getCarrierSyncInternal;
 
-export const [getTotalMemory, getTotalMemorySync] = getSupportedPlatformInfoFunctions({
+const [getTotalMemoryInternal, getTotalMemorySyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'totalMemory',
   supportedPlatforms: ['android', 'ios', 'windows', 'web'],
   getter: () => RNDeviceInfo.getTotalMemory(),
   syncGetter: () => RNDeviceInfo.getTotalMemorySync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the total memory information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getTotalMemory();
+ * ```
+ */
+export const getTotalMemory = getTotalMemoryInternal;
+/**
+ * Synchronous variant of {@link getTotalMemory}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getTotalMemorySync();
+ * ```
+ */
+export const getTotalMemorySync = getTotalMemorySyncInternal;
 
-export const [getMaxMemory, getMaxMemorySync] = getSupportedPlatformInfoFunctions({
+const [getMaxMemoryInternal, getMaxMemorySyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: 'maxMemory',
   supportedPlatforms: ['android', 'windows', 'web'],
   getter: () => RNDeviceInfo.getMaxMemory(),
   syncGetter: () => RNDeviceInfo.getMaxMemorySync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the max memory information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getMaxMemory();
+ * ```
+ */
+export const getMaxMemory = getMaxMemoryInternal;
+/**
+ * Synchronous variant of {@link getMaxMemory}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getMaxMemorySync();
+ * ```
+ */
+export const getMaxMemorySync = getMaxMemorySyncInternal;
 
-export const [getTotalDiskCapacity, getTotalDiskCapacitySync] = getSupportedPlatformInfoFunctions({
+const [getTotalDiskCapacityInternal, getTotalDiskCapacitySyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows', 'web'],
   getter: () => RNDeviceInfo.getTotalDiskCapacity(),
   syncGetter: () => RNDeviceInfo.getTotalDiskCapacitySync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the total disk capacity information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getTotalDiskCapacity();
+ * ```
+ */
+export const getTotalDiskCapacity = getTotalDiskCapacityInternal;
+/**
+ * Synchronous variant of {@link getTotalDiskCapacity}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getTotalDiskCapacitySync();
+ * ```
+ */
+export const getTotalDiskCapacitySync = getTotalDiskCapacitySyncInternal;
 
+/**
+ * Backwards-compatible wrapper for the legacy total disk capacity calculation on Android.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getTotalDiskCapacityOld();
+ * ```
+ */
 export async function getTotalDiskCapacityOld() {
   if (Platform.OS === 'android') {
     return RNDeviceInfo.getTotalDiskCapacityOld();
@@ -534,6 +1666,14 @@ export async function getTotalDiskCapacityOld() {
   return -1;
 }
 
+/**
+ * Synchronous variant of {@link getTotalDiskCapacityOld}.
+ *
+ * @example
+ * ```ts
+ * const result = getTotalDiskCapacityOldSync();
+ * ```
+ */
 export function getTotalDiskCapacityOldSync() {
   if (Platform.OS === 'android') {
     return RNDeviceInfo.getTotalDiskCapacityOldSync();
@@ -545,7 +1685,7 @@ export function getTotalDiskCapacityOldSync() {
   return -1;
 }
 
-export const [getFreeDiskStorage, getFreeDiskStorageSync] = getSupportedPlatformInfoFunctions({
+const [getFreeDiskStorageInternal, getFreeDiskStorageSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows', 'web'],
   getter: (storageType: AvailableCapacityType = 'total') => {
     if (Platform.OS === 'ios') {
@@ -563,7 +1703,40 @@ export const [getFreeDiskStorage, getFreeDiskStorageSync] = getSupportedPlatform
   },
   defaultValue: -1,
 });
+/**
+ * Retrieves the free disk storage information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getFreeDiskStorage();
+ * ```
+ */
+export const getFreeDiskStorage = getFreeDiskStorageInternal;
+/**
+ * Synchronous variant of {@link getFreeDiskStorage}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getFreeDiskStorageSync();
+ * ```
+ */
+export const getFreeDiskStorageSync = getFreeDiskStorageSyncInternal;
 
+/**
+ * Backwards-compatible wrapper for the legacy free disk storage calculation on Android.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getFreeDiskStorageOld();
+ * ```
+ */
 export async function getFreeDiskStorageOld() {
   if (Platform.OS === 'android') {
     return RNDeviceInfo.getFreeDiskStorageOld();
@@ -575,6 +1748,14 @@ export async function getFreeDiskStorageOld() {
   return -1;
 }
 
+/**
+ * Synchronous variant of {@link getFreeDiskStorageOld}.
+ *
+ * @example
+ * ```ts
+ * const result = getFreeDiskStorageOldSync();
+ * ```
+ */
 export function getFreeDiskStorageOldSync() {
   if (Platform.OS === 'android') {
     return RNDeviceInfo.getFreeDiskStorageOldSync();
@@ -586,14 +1767,37 @@ export function getFreeDiskStorageOldSync() {
   return -1;
 }
 
-export const [getBatteryLevel, getBatteryLevelSync] = getSupportedPlatformInfoFunctions({
+const [getBatteryLevelInternal, getBatteryLevelSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows', 'web'],
   getter: () => RNDeviceInfo.getBatteryLevel(),
   syncGetter: () => RNDeviceInfo.getBatteryLevelSync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the battery level information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getBatteryLevel();
+ * ```
+ */
+export const getBatteryLevel = getBatteryLevelInternal;
+/**
+ * Synchronous variant of {@link getBatteryLevel}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getBatteryLevelSync();
+ * ```
+ */
+export const getBatteryLevelSync = getBatteryLevelSyncInternal;
 
-export const [getPowerState, getPowerStateSync] = getSupportedPlatformInfoFunctions<
+const [getPowerStateInternal, getPowerStateSyncInternal] = getSupportedPlatformInfoFunctions<
   Partial<PowerState>
 >({
   supportedPlatforms: ['ios', 'android', 'windows', 'web'],
@@ -601,30 +1805,127 @@ export const [getPowerState, getPowerStateSync] = getSupportedPlatformInfoFuncti
   syncGetter: () => RNDeviceInfo.getPowerStateSync(),
   defaultValue: {},
 });
+/**
+ * Retrieves the power state information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getPowerState();
+ * ```
+ */
+export const getPowerState = getPowerStateInternal;
+/**
+ * Synchronous variant of {@link getPowerState}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getPowerStateSync();
+ * ```
+ */
+export const getPowerStateSync = getPowerStateSyncInternal;
 
-export const [isBatteryCharging, isBatteryChargingSync] = getSupportedPlatformInfoFunctions({
+const [isBatteryChargingInternal, isBatteryChargingSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'windows', 'web'],
   getter: () => RNDeviceInfo.isBatteryCharging(),
   syncGetter: () => RNDeviceInfo.isBatteryChargingSync(),
   defaultValue: false,
 });
+/**
+ * Returns true while the device battery is actively charging.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isBatteryCharging();
+ * ```
+ */
+export const isBatteryCharging = isBatteryChargingInternal;
+/**
+ * Synchronous variant of {@link isBatteryCharging}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isBatteryChargingSync();
+ * ```
+ */
+export const isBatteryChargingSync = isBatteryChargingSyncInternal;
 
+/**
+ * Resolves to true when the current screen dimensions indicate landscape orientation.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isLandscape();
+ * ```
+ */
 export async function isLandscape() {
   return Promise.resolve(isLandscapeSync());
 }
 
+/**
+ * Synchronous variant of {@link isLandscape}.
+ *
+ * @example
+ * ```ts
+ * const result = isLandscapeSync();
+ * ```
+ */
 export function isLandscapeSync() {
   const { height, width } = Dimensions.get('window');
   return width >= height;
 }
 
-export const [isAirplaneMode, isAirplaneModeSync] = getSupportedPlatformInfoFunctions({
+const [isAirplaneModeInternal, isAirplaneModeSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'web'],
   getter: () => RNDeviceInfo.isAirplaneMode(),
   syncGetter: () => RNDeviceInfo.isAirplaneModeSync(),
   defaultValue: false,
 });
+/**
+ * Returns true when the platform reports airplane mode is enabled.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isAirplaneMode();
+ * ```
+ */
+export const isAirplaneMode = isAirplaneModeInternal;
+/**
+ * Synchronous variant of {@link isAirplaneMode}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isAirplaneModeSync();
+ * ```
+ */
+export const isAirplaneModeSync = isAirplaneModeSyncInternal;
 
+/**
+ * Retrieves the device type information reported by the native platform.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getDeviceType();
+ * ```
+ */
 export const getDeviceType = () => {
   return getSupportedPlatformInfoSync({
     memoKey: 'deviceType',
@@ -634,6 +1935,14 @@ export const getDeviceType = () => {
   });
 };
 
+/**
+ * Synchronous variant of {@link getDeviceType}.
+ *
+ * @example
+ * ```ts
+ * const result = getDeviceTypeSync();
+ * ```
+ */
 export const getDeviceTypeSync = () => {
   return getSupportedPlatformInfoSync({
     memoKey: 'deviceType',
@@ -643,30 +1952,109 @@ export const getDeviceTypeSync = () => {
   });
 };
 
-export const [supportedAbis, supportedAbisSync] = getSupportedPlatformInfoFunctions({
+const [supportedAbisInternal, supportedAbisSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: '_supportedAbis',
   supportedPlatforms: ['android', 'ios', 'windows'],
   getter: () => RNDeviceInfo.getSupportedAbis(),
   syncGetter: () => RNDeviceInfo.getSupportedAbisSync(),
   defaultValue: [] as string[],
 });
+/**
+ * Lists the supported ABIs reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await supportedAbis();
+ * ```
+ */
+export const supportedAbis = supportedAbisInternal;
+/**
+ * Synchronous variant of {@link supportedAbis}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = supportedAbisSync();
+ * ```
+ */
+export const supportedAbisSync = supportedAbisSyncInternal;
 
-export const [supported32BitAbis, supported32BitAbisSync] = getSupportedPlatformInfoFunctions({
+const [supported32BitAbisInternal, supported32BitAbisSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: '_supported32BitAbis',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getSupported32BitAbis(),
   syncGetter: () => RNDeviceInfo.getSupported32BitAbisSync(),
   defaultValue: [] as string[],
 });
+/**
+ * Lists the supported 32 bit ABIs reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await supported32BitAbis();
+ * ```
+ */
+export const supported32BitAbis = supported32BitAbisInternal;
+/**
+ * Synchronous variant of {@link supported32BitAbis}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = supported32BitAbisSync();
+ * ```
+ */
+export const supported32BitAbisSync = supported32BitAbisSyncInternal;
 
-export const [supported64BitAbis, supported64BitAbisSync] = getSupportedPlatformInfoFunctions({
+const [supported64BitAbisInternal, supported64BitAbisSyncInternal] = getSupportedPlatformInfoFunctions({
   memoKey: '_supported64BitAbis',
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getSupported64BitAbis(),
   syncGetter: () => RNDeviceInfo.getSupported64BitAbisSync(),
   defaultValue: [],
 });
+/**
+ * Lists the supported 64 bit ABIs reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await supported64BitAbis();
+ * ```
+ */
+export const supported64BitAbis = supported64BitAbisInternal;
+/**
+ * Synchronous variant of {@link supported64BitAbis}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = supported64BitAbisSync();
+ * ```
+ */
+export const supported64BitAbisSync = supported64BitAbisSyncInternal;
 
+/**
+ * Reports whether the requested Android system feature is available on the device.
+ *
+ *![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const hasCamera = await hasSystemFeature('android.hardware.camera.any');
+ * ```
+ */
 export async function hasSystemFeature(feature: string) {
   if (Platform.OS === 'android') {
     return RNDeviceInfo.hasSystemFeature(feature);
@@ -674,6 +2062,14 @@ export async function hasSystemFeature(feature: string) {
   return false;
 }
 
+/**
+ * Synchronous variant of {@link hasSystemFeature}.
+ *
+ * @example
+ * ```ts
+ * const hasCamera = hasSystemFeatureSync('android.hardware.camera.any');
+ * ```
+ */
 export function hasSystemFeatureSync(feature: string) {
   if (Platform.OS === 'android') {
     return RNDeviceInfo.hasSystemFeatureSync(feature);
@@ -681,6 +2077,14 @@ export function hasSystemFeatureSync(feature: string) {
   return false;
 }
 
+/**
+ * Helper that classifies a normalized battery level as "low" using platform-specific thresholds.
+ *
+ * @example
+ * ```ts
+ * const isLow = isLowBatteryLevel(0.12);
+ * ```
+ */
 export function isLowBatteryLevel(level: number): boolean {
   if (Platform.OS === 'android') {
     return level < 0.15;
@@ -688,24 +2092,70 @@ export function isLowBatteryLevel(level: number): boolean {
   return level < 0.2;
 }
 
-export const [
-  getSystemAvailableFeatures,
-  getSystemAvailableFeaturesSync,
+const [
+  getSystemAvailableFeaturesInternal,
+  getSystemAvailableFeaturesSyncInternal,
 ] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getSystemAvailableFeatures(),
   syncGetter: () => RNDeviceInfo.getSystemAvailableFeaturesSync(),
   defaultValue: [] as string[],
 });
+/**
+ * Retrieves the system available features information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getSystemAvailableFeatures();
+ * ```
+ */
+export const getSystemAvailableFeatures = getSystemAvailableFeaturesInternal;
+/**
+ * Synchronous variant of {@link getSystemAvailableFeatures}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getSystemAvailableFeaturesSync();
+ * ```
+ */
+export const getSystemAvailableFeaturesSync = getSystemAvailableFeaturesSyncInternal;
 
-export const [isLocationEnabled, isLocationEnabledSync] = getSupportedPlatformInfoFunctions({
+const [isLocationEnabledInternal, isLocationEnabledSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios', 'web'],
   getter: () => RNDeviceInfo.isLocationEnabled(),
   syncGetter: () => RNDeviceInfo.isLocationEnabledSync(),
   defaultValue: false,
 });
+/**
+ * Returns true when the system-wide location services switch is enabled.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isLocationEnabled();
+ * ```
+ */
+export const isLocationEnabled = isLocationEnabledInternal;
+/**
+ * Synchronous variant of {@link isLocationEnabled}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isLocationEnabledSync();
+ * ```
+ */
+export const isLocationEnabledSync = isLocationEnabledSyncInternal;
 
-export const [isHeadphonesConnected, isHeadphonesConnectedSync] = getSupportedPlatformInfoFunctions(
+const [isHeadphonesConnectedInternal, isHeadphonesConnectedSyncInternal] = getSupportedPlatformInfoFunctions(
   {
     supportedPlatforms: ['android', 'ios'],
     getter: () => RNDeviceInfo.isHeadphonesConnected(),
@@ -713,51 +2163,196 @@ export const [isHeadphonesConnected, isHeadphonesConnectedSync] = getSupportedPl
     defaultValue: false,
   }
 );
+/**
+ * Returns true when any headphones are connected to the device.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isHeadphonesConnected();
+ * ```
+ */
+export const isHeadphonesConnected = isHeadphonesConnectedInternal;
+/**
+ * Synchronous variant of {@link isHeadphonesConnected}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isHeadphonesConnectedSync();
+ * ```
+ */
+export const isHeadphonesConnectedSync = isHeadphonesConnectedSyncInternal;
 
-export const [
-  isWiredHeadphonesConnected,
-  isWiredHeadphonesConnectedSync,
+const [
+  isWiredHeadphonesConnectedInternal,
+  isWiredHeadphonesConnectedSyncInternal,
 ] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios'],
   getter: () => RNDeviceInfo.isWiredHeadphonesConnected(),
   syncGetter: () => RNDeviceInfo.isWiredHeadphonesConnectedSync(),
   defaultValue: false,
 });
+/**
+ * Returns true when wired headphones are detected.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isWiredHeadphonesConnected();
+ * ```
+ */
+export const isWiredHeadphonesConnected = isWiredHeadphonesConnectedInternal;
+/**
+ * Synchronous variant of {@link isWiredHeadphonesConnected}.
+ *
+ * @example
+ * ```ts
+ * const result = isWiredHeadphonesConnectedSync();
+ * ```
+ */
+export const isWiredHeadphonesConnectedSync = isWiredHeadphonesConnectedSyncInternal;
 
-export const [
-  isBluetoothHeadphonesConnected,
-  isBluetoothHeadphonesConnectedSync,
+const [
+  isBluetoothHeadphonesConnectedInternal,
+  isBluetoothHeadphonesConnectedSyncInternal,
 ] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios'],
   getter: () => RNDeviceInfo.isBluetoothHeadphonesConnected(),
   syncGetter: () => RNDeviceInfo.isBluetoothHeadphonesConnectedSync(),
   defaultValue: false,
 });
+/**
+ * Returns true when Bluetooth headphones are connected.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isBluetoothHeadphonesConnected();
+ * ```
+ */
+export const isBluetoothHeadphonesConnected = isBluetoothHeadphonesConnectedInternal;
+/**
+ * Synchronous variant of {@link isBluetoothHeadphonesConnected}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isBluetoothHeadphonesConnectedSync();
+ * ```
+ */
+export const isBluetoothHeadphonesConnectedSync = isBluetoothHeadphonesConnectedSyncInternal;
 
-export const [isMouseConnected, isMouseConnectedSync] = getSupportedPlatformInfoFunctions({
+const [isMouseConnectedInternal, isMouseConnectedSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['windows'],
   getter: () => RNDeviceInfo.isMouseConnected(),
   syncGetter: () => RNDeviceInfo.isMouseConnectedSync(),
   defaultValue: false,
 });
+/**
+ * Returns true when a pointing device is connected (Windows).
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isMouseConnected();
+ * ```
+ */
+export const isMouseConnected = isMouseConnectedInternal;
+/**
+ * Synchronous variant of {@link isMouseConnected}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isMouseConnectedSync();
+ * ```
+ */
+export const isMouseConnectedSync = isMouseConnectedSyncInternal;
 
-export const [isKeyboardConnected, isKeyboardConnectedSync] = getSupportedPlatformInfoFunctions({
+const [isKeyboardConnectedInternal, isKeyboardConnectedSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['windows'],
   getter: () => RNDeviceInfo.isKeyboardConnected(),
   syncGetter: () => RNDeviceInfo.isKeyboardConnectedSync(),
   defaultValue: false,
 });
+/**
+ * Returns true when a hardware keyboard is connected (Windows).
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isKeyboardConnected();
+ * ```
+ */
+export const isKeyboardConnected = isKeyboardConnectedInternal;
+/**
+ * Synchronous variant of {@link isKeyboardConnected}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = isKeyboardConnectedSync();
+ * ```
+ */
+export const isKeyboardConnectedSync = isKeyboardConnectedSyncInternal;
 
-export const [
-  getSupportedMediaTypeList,
-  getSupportedMediaTypeListSync,
+const [
+  getSupportedMediaTypeListInternal,
+  getSupportedMediaTypeListSyncInternal,
 ] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android'],
   getter: () => RNDeviceInfo.getSupportedMediaTypeList(),
   syncGetter: () => RNDeviceInfo.getSupportedMediaTypeListSync(),
   defaultValue: [],
 });
+/**
+ * Retrieves the supported media type list information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getSupportedMediaTypeList();
+ * ```
+ */
+export const getSupportedMediaTypeList = getSupportedMediaTypeListInternal;
+/**
+ * Synchronous variant of {@link getSupportedMediaTypeList}.
+ *
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getSupportedMediaTypeListSync();
+ * ```
+ */
+export const getSupportedMediaTypeListSync = getSupportedMediaTypeListSyncInternal;
 
+/**
+ * Returns true when Windows tablet mode is currently active.
+ *
+ *![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await isTabletMode();
+ * ```
+ */
 export const isTabletMode = () =>
   getSupportedPlatformInfoAsync({
     supportedPlatforms: ['windows'],
@@ -765,23 +2360,79 @@ export const isTabletMode = () =>
     defaultValue: false,
   });
 
-export const [
-  getAvailableLocationProviders,
-  getAvailableLocationProvidersSync,
+const [
+  getAvailableLocationProvidersInternal,
+  getAvailableLocationProvidersSyncInternal,
 ] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['android', 'ios'],
   getter: () => RNDeviceInfo.getAvailableLocationProviders(),
   syncGetter: () => RNDeviceInfo.getAvailableLocationProvidersSync(),
   defaultValue: {},
 });
+/**
+ * Retrieves the available location providers information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getAvailableLocationProviders();
+ * ```
+ */
+export const getAvailableLocationProviders = getAvailableLocationProvidersInternal;
+/**
+ * Synchronous variant of {@link getAvailableLocationProviders}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getAvailableLocationProvidersSync();
+ * ```
+ */
+export const getAvailableLocationProvidersSync = getAvailableLocationProvidersSyncInternal;
 
-export const [getBrightness, getBrightnessSync] = getSupportedPlatformInfoFunctions({
+const [getBrightnessInternal, getBrightnessSyncInternal] = getSupportedPlatformInfoFunctions({
   supportedPlatforms: ['ios'],
   getter: () => RNDeviceInfo.getBrightness(),
   syncGetter: () => RNDeviceInfo.getBrightnessSync(),
   defaultValue: -1,
 });
+/**
+ * Retrieves the brightness information reported by the native platform.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getBrightness();
+ * ```
+ */
+export const getBrightness = getBrightnessInternal;
+/**
+ * Synchronous variant of {@link getBrightness}.
+ *
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = getBrightnessSync();
+ * ```
+ */
+export const getBrightnessSync = getBrightnessSyncInternal;
 
+/**
+ * Retrieves the native APNS device token that can be used for remote push notifications on iOS.
+ *
+ *![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```ts
+ * const result = await getDeviceToken();
+ * ```
+ */
 export async function getDeviceToken() {
   if (Platform.OS === 'ios') {
     return RNDeviceInfo.getDeviceToken();
@@ -790,6 +2441,19 @@ export async function getDeviceToken() {
 }
 
 const deviceInfoEmitter = new NativeEventEmitter(NativeModules.RNDeviceInfo);
+/**
+ * React hook that streams battery level updates emitted by the native module.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function BatteryIndicator() {
+ *   const level = useBatteryLevel();
+ *   return <Text>{level ?? 'unknown'}%</Text>;
+ * }
+ * ```
+ */
 export function useBatteryLevel(): number | null {
   const [batteryLevel, setBatteryLevel] = useState<number | null>(null);
 
@@ -816,6 +2480,22 @@ export function useBatteryLevel(): number | null {
   return batteryLevel;
 }
 
+/**
+ * React hook that notifies when the battery crosses the low-level threshold.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io-badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function LowBatteryBanner() {
+ *   const level = useBatteryLevelIsLow();
+ *   if (level == null) {
+ *     return null;
+ *   }
+ *   return <Banner title={`Battery low (${Math.round(level * 100)}%)`} />;
+ * }
+ * ```
+ */
 export function useBatteryLevelIsLow(): number | null {
   const [batteryLevelIsLow, setBatteryLevelIsLow] = useState<number | null>(null);
 
@@ -839,6 +2519,19 @@ export function useBatteryLevelIsLow(): number | null {
   return batteryLevelIsLow;
 }
 
+/**
+ * React hook that subscribes to power state changes and returns a partial {@link PowerState}.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ✅](https://img.shields.io/badge/Web-%E2%9C%85-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function ChargingStatus() {
+ *   const powerState = usePowerState();
+ *   return <Text>{powerState.batteryState}</Text>;
+ * }
+ * ```
+ */
 export function usePowerState(): Partial<PowerState> {
   const [powerState, setPowerState] = useState<Partial<PowerState>>({});
 
@@ -865,10 +2558,36 @@ export function usePowerState(): Partial<PowerState> {
   return powerState;
 }
 
+/**
+ * React hook that resolves to true whenever any headphones are connected.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function HeadphoneBadge() {
+ *   const { result: connected } = useIsHeadphonesConnected();
+ *   return connected ? <Badge text="Headphones" /> : null;
+ * }
+ * ```
+ */
 export function useIsHeadphonesConnected(): AsyncHookResult<boolean> {
   return useOnEvent('RNDeviceInfo_headphoneConnectionDidChange', isHeadphonesConnected, false);
 }
 
+/**
+ * React hook that resolves to true whenever wired headphones are connected.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function WiredOnlyNotice() {
+ *   const { result } = useIsWiredHeadphonesConnected();
+ *   return result ? <Text>Wired audio active</Text> : null;
+ * }
+ * ```
+ */
 export function useIsWiredHeadphonesConnected(): AsyncHookResult<boolean> {
   return useOnEvent(
     'RNDeviceInfo_headphoneWiredConnectionDidChange',
@@ -877,6 +2596,19 @@ export function useIsWiredHeadphonesConnected(): AsyncHookResult<boolean> {
   );
 }
 
+/**
+ * React hook that resolves to true whenever Bluetooth headphones are connected.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function BluetoothAudioIndicator() {
+ *   const { result } = useIsBluetoothHeadphonesConnected();
+ *   return result ? <Icon name="bluetooth-audio" /> : null;
+ * }
+ * ```
+ */
 export function useIsBluetoothHeadphonesConnected(): AsyncHookResult<boolean> {
   return useOnEvent(
     'RNDeviceInfo_headphoneBluetoothConnectionDidChange',
@@ -885,27 +2617,105 @@ export function useIsBluetoothHeadphonesConnected(): AsyncHookResult<boolean> {
   );
 }
 
+/**
+ * React hook that exposes the app's first install timestamp once it is retrieved.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function InstallAge() {
+ *   const { result } = useFirstInstallTime();
+ *   return <Text>{new Date(result).toLocaleDateString()}</Text>;
+ * }
+ * ```
+ */
 export function useFirstInstallTime(): AsyncHookResult<number> {
   return useOnMount(getFirstInstallTime, -1);
 }
 
+/**
+ * React hook that resolves with the human-readable device name when it becomes available.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function Greeting() {
+ *   const { result: name } = useDeviceName();
+ *   return <Text>Hello from {name}</Text>;
+ * }
+ * ```
+ */
 export function useDeviceName(): AsyncHookResult<string> {
   return useOnMount(getDeviceName, 'unknown');
 }
 
+/**
+ * React hook that checks for an Android system feature and keeps the result cached.
+ *
+ * **Compatibility:** ![iOS ❌](https://img.shields.io/badge/iOS-%E2%9D%8C-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function FaceUnlockOnly() {
+ *   const { result } = useHasSystemFeature('android.hardware.biometrics.face');
+ *   return <Text>{result ? 'Face unlock supported' : 'Face unlock unavailable'}</Text>;
+ * }
+ * ```
+ */
 export function useHasSystemFeature(feature: string): AsyncHookResult<boolean> {
   const asyncGetter = useCallback(() => hasSystemFeature(feature), [feature]);
   return useOnMount(asyncGetter, false);
 }
 
+/**
+ * React hook that resolves as soon as the emulator detection result is known.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function IsEmulatorCallout() {
+ *   const { result: emulator } = useIsEmulator();
+ *   return emulator ? <Text>Running on emulator</Text> : null;
+ * }
+ * ```
+ */
 export function useIsEmulator(): AsyncHookResult<boolean> {
   return useOnMount(isEmulator, false);
 }
 
+/**
+ * React hook that resolves to the device manufacturer string.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ✅](https://img.shields.io/badge/Android-%E2%9C%85-informational?labelColor=555555) ![Windows ✅](https://img.shields.io/badge/Windows-%E2%9C%85-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ✅](https://img.shields.io/badge/visionOS-%E2%9C%85-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function ManufacturerLine() {
+ *   const { result: manufacturer } = useManufacturer();
+ *   return <Text>Made by {manufacturer}</Text>;
+ * }
+ * ```
+ */
 export function useManufacturer(): AsyncHookResult<string> {
   return useOnMount(getManufacturer, 'unknown');
 }
 
+/**
+ * React hook that subscribes to screen brightness updates on iOS.
+ *
+ * **Compatibility:** ![iOS ✅](https://img.shields.io/badge/iOS-%E2%9C%85-informational?labelColor=555555) ![Android ❌](https://img.shields.io/badge/Android-%E2%9D%8C-informational?labelColor=555555) ![Windows ❌](https://img.shields.io/badge/Windows-%E2%9D%8C-informational?labelColor=555555) ![Web ❌](https://img.shields.io/badge/Web-%E2%9D%8C-informational?labelColor=555555) ![visionOS ❌](https://img.shields.io/badge/visionOS-%E2%9D%8C-informational?labelColor=555555)
+ *
+ * @example
+ * ```tsx
+ * function BrightnessSlider() {
+ *   const brightness = useBrightness();
+ *   return <Slider value={brightness ?? 0} disabled />;
+ * }
+ * ```
+ */
 export function useBrightness(): number | null {
   const [brightness, setBrightness] = useState<number | null>(null);
 
@@ -934,7 +2744,10 @@ export function useBrightness(): number | null {
 
 export type { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState, AppSetIdInfo };
 
-const DeviceInfo: DeviceInfoModule = {
+/**
+ * CommonJS-style namespace that aggregates every exported API from this module.
+ */
+export const DeviceInfo: DeviceInfoModule = {
   getAndroidId,
   getAndroidIdSync,
   getApiLevel,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -205,17 +205,113 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   supported64BitAbisSync: () => string[];
   supportedAbis: () => Promise<string[]>;
   supportedAbisSync: () => string[];
+  /**
+   * React hook that streams battery level updates emitted by the native module.
+   *
+   * @example
+   * ```tsx
+   * const level = useBatteryLevel();
+   * ```
+   */
   useBatteryLevel: () => number | null;
+  /**
+   * React hook that notifies when the battery crosses the low-level threshold.
+   *
+   * @example
+   * ```tsx
+   * const level = useBatteryLevelIsLow();
+   * ```
+   */
   useBatteryLevelIsLow: () => number | null;
+  /**
+   * React hook that resolves with the human-readable device name when it becomes available.
+   *
+   * @example
+   * ```tsx
+   * const { result: name } = useDeviceName();
+   * ```
+   */
   useDeviceName: () => AsyncHookResult<string>;
+  /**
+   * React hook that exposes the app's first install timestamp once it is retrieved.
+   *
+   * @example
+   * ```tsx
+   * const { result } = useFirstInstallTime();
+   * ```
+   */
   useFirstInstallTime: () => AsyncHookResult<number>;
+  /**
+   * React hook that checks for an Android system feature and keeps the result cached.
+   *
+   * @example
+   * ```tsx
+   * const { result } = useHasSystemFeature('android.hardware.location.gps');
+   * ```
+   */
   useHasSystemFeature: (feature: string) => AsyncHookResult<boolean>;
+  /**
+   * React hook that resolves as soon as the emulator detection result is known.
+   *
+   * @example
+   * ```tsx
+   * const { result: emulator } = useIsEmulator();
+   * ```
+   */
   useIsEmulator: () => AsyncHookResult<boolean>;
+  /**
+   * React hook that subscribes to power state changes and returns a partial {@link PowerState}.
+   *
+   * @example
+   * ```tsx
+   * const powerState = usePowerState();
+   * ```
+   */
   usePowerState: () => Partial<PowerState>;
+  /**
+   * React hook that resolves to the device manufacturer string.
+   *
+   * @example
+   * ```tsx
+   * const { result: manufacturer } = useManufacturer();
+   * ```
+   */
   useManufacturer: () => AsyncHookResult<string>;
+  /**
+   * React hook that resolves to true whenever any headphones are connected.
+   *
+   * @example
+   * ```tsx
+   * const { result: connected } = useIsHeadphonesConnected();
+   * ```
+   */
   useIsHeadphonesConnected: () => AsyncHookResult<boolean>;
+  /**
+   * React hook that resolves to true whenever wired headphones are connected.
+   *
+   * @example
+   * ```tsx
+   * const { result } = useIsWiredHeadphonesConnected();
+   * ```
+   */
   useIsWiredHeadphonesConnected: () => AsyncHookResult<boolean>;
+  /**
+   * React hook that resolves to true whenever Bluetooth headphones are connected.
+   *
+   * @example
+   * ```tsx
+   * const { result } = useIsBluetoothHeadphonesConnected();
+   * ```
+   */
   useIsBluetoothHeadphonesConnected: () => AsyncHookResult<boolean>;
+  /**
+   * React hook that subscribes to screen brightness updates on iOS.
+   *
+   * @example
+   * ```tsx
+   * const brightness = useBrightness();
+   * ```
+   */
   useBrightness: () => number | null;
   getAppSetId: () => Promise<AppSetIdInfo>;
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,7 +1,16 @@
+/**
+ * High-level classification of the device hardware.
+ */
 export type DeviceType = 'Handset' | 'Tablet' | 'Tv' | 'Desktop' | 'GamingConsole' | 'unknown';
 
+/**
+ * Possible power states reported by the native layer.
+ */
 export type BatteryState = 'unknown' | 'unplugged' | 'charging' | 'full';
 
+/**
+ * Snapshot of the device's current power conditions.
+ */
 export interface PowerState {
   batteryLevel: number;
   batteryState: BatteryState;
@@ -9,22 +18,35 @@ export interface PowerState {
   [key: string]: any;
 }
 
+/**
+ * Map describing which location providers are currently enabled.
+ */
 export interface LocationProviderInfo {
   [key: string]: boolean;
 }
 
+/**
+ * Shared shape returned by asynchronous hooks in this module.
+ */
 export interface AsyncHookResult<T> {
   loading: boolean;
   result: T;
 }
 
-// Only relevant for iOS
+/**
+ * Disk capacity buckets used by iOS when querying storage information.
+ */
 export type AvailableCapacityType = 'total' | 'important' | 'opportunistic';
 
-// AppSetId types for Android
+/**
+ * Google Play Services App Set ID payload describing identifier and scope.
+ */
 export interface AppSetIdInfo {
   id: string;
   scope: number;
 }
 
-export type AppSetIdScope = 1 | 2; // SCOPE_APP = 1, SCOPE_DEVELOPER = 2
+/**
+ * Allowed scope values returned with the App Set ID (1: app, 2: developer).
+ */
+export type AppSetIdScope = 1 | 2;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "moduleResolution": "node",
     "lib": ["es2015", "es2016", "esnext"],
     "jsx": "react-native",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.json",
+  "out": "docs",
+  "excludePrivate": true,
+  "excludeExternals": true,
+  "includeVersion": true
+}


### PR DESCRIPTION
## Summary
This pull request introduces improvements to developer documentation and enhances type safety and clarity in the codebase. The most important changes are the addition of a new workflow for building and deploying documentation, updates to the documentation scripts, and expanded type definitions with detailed comments.

**Documentation automation and scripts:**

* Added a new GitHub Actions workflow (`.github/workflows/docs-pages.yml`) to automatically build and deploy documentation to GitHub Pages on every push to `master`.
* Updated `package.json` to include new scripts for generating (`docs`) and serving (`docs:serve`) documentation using TypeDoc and http-server.
* Added a TypeDoc configuration file (`typedoc.json`) to define documentation output and options.

**Type definitions and code comments:**

* Expanded type definitions in `src/internal/types.ts` with detailed comments and documentation for device types, battery states, power state, location provider info, asynchronous hook results, disk capacity types, and App Set ID types.
* Added JSDoc comments to the `DeviceInfoModule` interface in `src/internal/privateTypes.ts`, describing the purpose and usage of each React hook provided by the module.

## TL;DR

adds comments and does some slight refactoring in order to add comments for [`typedoc`](https://typedoc.org/) to use when generating the documentation site pages. 

adds a workflow that runs on every push to master to update the documentation

This will deploy to github pages:

<img width="1436" height="971" alt="Screenshot 2025-11-12 at 21 24 32" src="https://github.com/user-attachments/assets/a915ed21-207f-484a-b97c-66d149f64979" />
